### PR TITLE
index json

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -55,6 +55,7 @@ variantlib = "variantlib.commands.main:main"
 [project.entry-points."variantlib.actions"]
 analyze_wheel = "variantlib.commands.analyze_wheel:analyze_wheel"
 analyze_platform = "variantlib.commands.analyze_platform:analyze_platform"
+generate_index_json = "variantlib.commands.generate_index_json:generate_index_json"
 
 [tool.pytest.ini_options]
 testpaths = ["tests/"]

--- a/variantlib/commands/generate_index_json.py
+++ b/variantlib/commands/generate_index_json.py
@@ -1,0 +1,87 @@
+import argparse
+import email.parser
+import email.policy
+import json
+import logging
+import pathlib
+import zipfile
+
+from variantlib.meta import VariantMeta
+
+logger = logging.getLogger(__name__)
+logger.setLevel(logging.INFO)
+
+
+def generate_index_json(args):
+    parser = argparse.ArgumentParser(
+        prog="generate_index_json",
+        description="Generate a JSON index of all package variants",
+    )
+    parser.add_argument(
+        "-d",
+        "--directory",
+        type=pathlib.Path,
+        required=True,
+        help="Directory to process",
+    )
+
+    parsed_args = parser.parse_args(args)
+
+    directory = parsed_args.directory
+
+    if not directory.exists():
+        raise FileNotFoundError(f"Directory not found: `{directory}`")
+    if not directory.is_dir():
+        raise NotADirectoryError(f"Directory not found: `{directory}`")
+
+    metadata_parser = email.parser.BytesParser(policy=email.policy.compat32)
+    known_variants = {}
+    known_providers = set()
+
+    for wheel in directory.glob("*.whl"):
+        with zipfile.ZipFile(wheel, "r") as zip_file:
+            for name in zip_file.namelist():
+                if name.endswith(".dist-info/METADATA"):
+                    with zip_file.open(name) as f:
+                        metadata = metadata_parser.parse(f, headersonly=True)
+                    break
+            else:
+                logger.warning(f"{wheel}: no METADATA file found")
+                continue
+
+            if (variant_hash := metadata.get("Variant-hash")) is None:
+                logger.info(f"{wheel}: no Variant-hash")
+                continue
+            if (variant_entries := metadata.get_all("Variant")) is None:
+                logger.warn(f"{wheel}: Variant-hash present but no Variant metadata")
+                continue
+
+            variant_dict = {}
+            for variant_entry in variant_entries:
+                variant_meta = VariantMeta.from_str(variant_entry)
+                provider_dict = variant_dict.setdefault(variant_meta.provider, {})
+                if variant_meta.key in provider_dict:
+                    logger.warn(
+                        f"{wheel}: Duplicate key: {variant_meta.provider} :: {variant_meta.key}"
+                    )
+                provider_dict[variant_meta.key] = variant_meta.value
+                known_providers.add(variant_meta.provider)
+
+            if (existing_entry := known_variants.get(variant_hash)) is None:
+                known_variants[variant_hash] = variant_dict
+            elif existing_entry != variant_dict:
+                raise ValueError(
+                    f"{wheel}: different metadata assigned to {variant_hash}"
+                )
+
+    provider_requires = []
+    # TODO: map provider into package names
+
+    with directory.joinpath("variants.json").open("w") as f:
+        json.dump(
+            {
+                "provider-requires": provider_requires,
+                "variants": known_variants,
+            },
+            f
+        )


### PR DESCRIPTION
Here's a prototype implementation. Given a `directory`, it reads variant metadata from all `*.whl` files, and writes a `variants.json` file.

Here's an example file from `mockhouse/pep-xxx-variants/dummy-project/`, pretty-printed using `json_pp` (the output is compacted):

```json
{
   "provider-requires" : [
      "provider_fictional_hw",
      "provider_fictional_tech"
   ],
   "variants" : {
      "36266d4d" : {
         "fictional_hw" : {
            "architecture" : "HAL9000",
            "compute_accuracy" : "0",
            "compute_capability" : "6",
            "humor" : "2"
         }
      },
      "4f8ae729" : {
         "fictional_hw" : {
            "architecture" : "tars",
            "compute_accuracy" : "8",
            "compute_capability" : "8",
            "humor" : "10"
         }
      },
      "57768a46" : {
         "fictional_tech" : {
            "quantum" : "FOAM",
            "risk_exposure" : "1000000000",
            "technology" : "improb_drive"
         }
      },
      "6b4c8391" : {
         "fictional_hw" : {
            "architecture" : "deepthought",
            "compute_accuracy" : "10",
            "compute_capability" : "10",
            "humor" : "0"
         },
         "fictional_tech" : {
            "quantum" : "FOAM"
         }
      },
      "9091cdc4" : {
         "fictional_tech" : {
            "quantum" : "SUPERPOSITION",
            "risk_exposure" : "25",
            "technology" : "auto_chef"
         }
      },
      "e684be6f" : {
         "fictional_hw" : {
            "architecture" : "mother",
            "compute_capability" : "4"
         }
      }
   }
}
```