### PR TITLE
[WheelVariants] Implement getting sorted variants aided by `variants.json`

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,26 @@
+name: CI
+on: [push, pull_request]
+jobs:
+  test:
+    strategy:
+      matrix:
+        python-version: ["3.10", "3.11", "3.12", "3.13", "pypy-3.10", "pypy-3.11"]
+      fail-fast: false
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: ${{ matrix.python-version }}
+      - name: Install uv
+        uses: astral-sh/setup-uv@v5
+        with:
+          python-version: ${{ matrix.python-version }}
+      - name: Install the package and test dependencies
+        run: |
+          uv venv
+          uv pip install -e '.[test]'
+      - name: Run tests
+        run: uv run --no-project pytest

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -40,6 +40,7 @@ dev = [
 ]
 test = [
     "jsondiff>=2.2,<2.3",
+    "hypothesis>=6.0.0,<7",
     "pytest>=8.0.0,<9.0.0",
     "pytest-cov>=5.0.0,<6.0.0",
     "pytest-dotenv>=0.5.0,<1.0.0",

--- a/tests/test_combinations.py
+++ b/tests/test_combinations.py
@@ -4,6 +4,7 @@ import random
 import string
 
 from hypothesis import assume
+from hypothesis import example
 from hypothesis import given
 from hypothesis import strategies as st
 import jsondiff
@@ -68,6 +69,19 @@ def test_filtered_sorted_variants_roundtrip(configs):
     assert filtered_sorted_variants(variants_from_json, configs) == combinations
 
 
+@example(
+    [
+        ProviderConfig(
+            provider="A",
+            configs=[
+                KeyConfig(key="A1", values=["x"]),
+                KeyConfig(key="A2", values=["x"]),
+            ],
+        ),
+        ProviderConfig(provider="B", configs=[KeyConfig(key="B1", values=["x"])]),
+        ProviderConfig(provider="C", configs=[KeyConfig(key="C1", values=["x"])]),
+    ]
+)
 @given(
     st.lists(
         min_size=1,

--- a/variantlib/combination.py
+++ b/variantlib/combination.py
@@ -88,12 +88,14 @@ def filtered_sorted_variants(variants_from_json: dict,
         # Variants with more matched values should go first.
         yield -len(desc.data)
         # Sort meta sort keys by their sort keys, so that metas containing
-        # more preferred sort key sort first.  We then combine these sorted
-        # sort keys, so that descs themselves are sorted according to their
-        # most preferred (provider, key, value) tuples -- and if these match,
-        # they sort according to the next most preferred tuple, and so on.
-        for x in sorted(meta_key(x) for x in desc.data):
-            yield from x
+        # more preferred sort key sort first.
+        meta_keys = sorted(meta_key(x) for x in desc.data)
+        # Order by provider priority first (variants with higher priority
+        # providers always go over lower priority providers), then by key
+        # and value priorities.
+        yield from (x[0] for x in meta_keys)
+        yield from (x[1] for x in meta_keys)
+        yield from (x[2] for x in meta_keys)
 
     res = sorted(filter(variant_filter,
                         unpack_variants_from_json(variants_from_json)),

--- a/variantlib/combination.py
+++ b/variantlib/combination.py
@@ -57,7 +57,7 @@ def filtered_sorted_variants(variants_from_json: dict,
 
     def variant_filter(desc: VariantDescription):
         # Filter out the variant, unless all of its metas are supported.
-        return all(meta.value in providers.get(meta.provider, {})[1].get(meta.key, {})[1]
+        return all(meta.value in providers.get(meta.provider, (0, {}))[1].get(meta.key, (0, {}))[1]
                    for meta in desc)
 
     def meta_key(meta: VariantMeta) -> tuple[int, int, int]:

--- a/variantlib/combination.py
+++ b/variantlib/combination.py
@@ -90,11 +90,8 @@ def filtered_sorted_variants(variants_from_json: dict,
         # Sort meta sort keys by their sort keys, so that metas containing
         # more preferred sort key sort first.
         meta_keys = sorted(meta_key(x) for x in desc.data)
-        # Order by provider priority first (variants with higher priority
-        # providers always go over lower priority providers), then by key
-        # and value priorities.
-        yield from (x[0] for x in meta_keys)
-        yield from (x[1] for x in meta_keys)
+        # Always prefer all values from the "stronger" keys over "weaker".
+        yield from (x[0:2] for x in meta_keys)
         yield from (x[2] for x in meta_keys)
 
     res = sorted(filter(variant_filter,


### PR DESCRIPTION
Add a `variants_json` argument to `get_variant_hashes_by_priority()` that enables the function to use variant definitions from `variants.json` instead of evaluating all possible combinations. This can yield significant speedup and lower resource use if only a handful of variants need to be considered.

The function is implemented without any plugin API changes.  After all, the current API should be simpler for plugin authors, and generating separate variant lists should not pose a performance problem.

Implemention-wise, the function first converts all variant descriptions from `variants.json` into `VariantDescription` classes.  Then, the list of variants is fitlered to include only variants that match configurations obtained from plugins.  Finally, they are sorted using the configuration order.

I am not 100% sure about the sorting algorithm, but it seems to yield exactly the same order at least for the `dummy-project` wheels. The first element of the sort key is the number of metas in the variant, to prioritize variants that matched more items.  It is followed by priorities (indices in configuration order) of all metas, ordered from the most preferred to the least preferred.