### PR TITLE
[Removal of `attrs`] Replacing with `dataclass`

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -28,7 +28,7 @@ maintainers = [
     { name = "Jonathan Dekhtiar", email = "jonathan@dekhtiar.com" },
     { name = "Michael Sarahan", email = "msarahan@nvidia.com" },
 ]
-dependencies = ["attrs>=24.3,<24.4"]
+dependencies = []
 
 [project.optional-dependencies]
 dev = [

--- a/tests/test_combinations.py
+++ b/tests/test_combinations.py
@@ -1,14 +1,16 @@
 import json
-from pathlib import Path
 import random
 import string
+from collections.abc import Generator
+from pathlib import Path
 
+import jsondiff
+import pytest
 from hypothesis import assume
 from hypothesis import example
 from hypothesis import given
 from hypothesis import strategies as st
-import jsondiff
-import pytest
+
 from variantlib.combination import filtered_sorted_variants
 from variantlib.combination import get_combinations
 from variantlib.config import KeyConfig
@@ -51,7 +53,7 @@ def test_get_combinations(configs):
     assert not differences, f"Serialization altered JSON: {differences}"
 
 
-def desc_to_json(desc_list: list[VariantDescription]) -> dict:
+def desc_to_json(desc_list: list[VariantDescription]) -> Generator:
     shuffled_desc_list = list(desc_list)
     random.shuffle(shuffled_desc_list)
     for desc in shuffled_desc_list:
@@ -63,9 +65,10 @@ def desc_to_json(desc_list: list[VariantDescription]) -> dict:
 
 
 def test_filtered_sorted_variants_roundtrip(configs):
-    """Test that we can round-trip all combinations via variants.json and get the same result."""
+    """Test that we can round-trip all combinations via variants.json and get the same
+    result."""
     combinations = list(get_combinations(configs))
-    variants_from_json = {k: v for k, v in desc_to_json(combinations)}
+    variants_from_json = dict(desc_to_json(combinations))
     assert filtered_sorted_variants(variants_from_json, configs) == combinations
 
 
@@ -125,5 +128,5 @@ def test_filtered_sorted_variants_roundtrip_fuzz(configs):
             yield x
 
     combinations = list(filter_long_combinations())
-    variants_from_json = {k: v for k, v in desc_to_json(combinations)}
+    variants_from_json = dict(desc_to_json(combinations))
     assert filtered_sorted_variants(variants_from_json, configs) == combinations

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -86,7 +86,7 @@ def test_provider_config_invalid_configs_type():
 
 def test_provider_config_invalid_key_type_in_configs():
     """Test that invalid `KeyConfig` inside `ProviderConfig` raises an error."""
-    with pytest.raises(AssertionError):
+    with pytest.raises(TypeError):
         ProviderConfig(
             provider="provider_name",
             configs=[{"key": "attr_nameA", "values": ["7", "4", "8", "12"]}],
@@ -103,7 +103,7 @@ def test_provider_config_invalid_key_config_type():
     """Test that invalid key config types within ProviderConfig raise an error."""
     from types import SimpleNamespace
 
-    with pytest.raises(AssertionError):
+    with pytest.raises(TypeError):
         ProviderConfig(
             provider="provider_name",
             configs=[

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -1,4 +1,5 @@
 import pytest
+
 from variantlib.config import KeyConfig
 from variantlib.config import ProviderConfig
 
@@ -7,7 +8,7 @@ def test_key_config_creation_valid():
     """Test valid creation of KeyConfig."""
     key_config = KeyConfig(key="attr_nameA", values=["7", "4", "8", "12"])
     assert key_config.key == "attr_nameA"
-    assert key_config.values == ["7", "4", "8", "12"]  # noqa: PD011
+    assert key_config.values == ["7", "4", "8", "12"]
 
 
 def test_provider_config_creation_valid():

--- a/tests/test_meta.py
+++ b/tests/test_meta.py
@@ -3,6 +3,7 @@ import random
 import string
 
 import pytest
+
 from variantlib import VARIANT_HASH_LEN
 from variantlib.meta import VariantDescription
 from variantlib.meta import VariantMeta
@@ -193,7 +194,7 @@ def test_variantdescription_invalid_data():
         "key": "access_key",
         "value": "secret_value",
     }
-    with pytest.raises(AssertionError):
+    with pytest.raises(TypeError):
         VariantDescription([invalid_meta])
 
 

--- a/variantlib/meta.py
+++ b/variantlib/meta.py
@@ -89,7 +89,6 @@ class VariantMeta:
 
 
 @dataclass(frozen=True)
-# @dataclass
 class VariantDescription:
     """
     A `Variant` is being described by a N >= 1 `VariantMeta` metadata.

--- a/variantlib/platform.py
+++ b/variantlib/platform.py
@@ -2,7 +2,6 @@ from __future__ import annotations
 
 import logging
 from collections import defaultdict
-from functools import cache
 from importlib.metadata import entry_points
 from typing import TYPE_CHECKING
 
@@ -19,6 +18,8 @@ logger = logging.getLogger(__name__)
 
 
 class VariantCache:
+    """This class is not necessary today - can be used for finer cache control later."""
+
     def __init__(self):
         self.cache = None
 
@@ -137,7 +138,9 @@ def get_variant_hashes_by_priority(
 
     if sorted_provider_cfgs:
         if (variants_json or {}).get("variants") is not None:
-            for variant_desc in filtered_sorted_variants(variants_json["variants"], sorted_provider_cfgs):
+            for variant_desc in filtered_sorted_variants(
+                variants_json["variants"], sorted_provider_cfgs
+            ):
                 yield variant_desc.hexdigest
         else:
             for variant_desc in get_combinations(sorted_provider_cfgs):

--- a/variantlib/validators.py
+++ b/variantlib/validators.py
@@ -1,0 +1,18 @@
+import re
+from typing import Any
+
+
+def validate_instance_of(value: Any, expected_type: type) -> None:
+    if not isinstance(value, expected_type):
+        raise TypeError(f"Expected {expected_type}, got {type(value)}")
+
+
+def validate_list_of(data: list[Any], expected_type: type) -> None:
+    for value in data:
+        if not isinstance(value, expected_type):
+            raise TypeError(f"Expected {expected_type}, got {type(value)}")
+
+
+def validate_matches_re(value: str, pattern: str) -> None:
+    if not re.match(pattern, value):
+        raise ValueError(f"Value must match regex {pattern}")


### PR DESCRIPTION
This PR removes `attrs` in favor of `dataclass` while changing an absolute minimum of things and remaining all the data validation and the unittests / fuzzy testing.