### PR TITLE
Relax whitespace requirements in `VariantMeta.from_str()`

### DIFF
--- a/tests/test_meta.py
+++ b/tests/test_meta.py
@@ -90,9 +90,16 @@ def test_failing_regex_value():
             _ = VariantMeta(provider="provider", key="key", value=f"val{c}ue")
 
 
-def test_from_str_valid():
+@pytest.mark.parametrize(
+    "input_str",
+    [
+        "OmniCorp :: access_key :: secret_value",
+        "OmniCorp::access_key::secret_value",
+        "OmniCorp ::access_key::     secret_value",
+    ],
+)
+def test_from_str_valid(input_str: str):
     # Test case: Valid string input
-    input_str = "OmniCorp :: access_key :: secret_value"
     variant_meta = VariantMeta.from_str(input_str)
 
     # Check if the resulting object matches the expected values

--- a/variantlib/meta.py
+++ b/variantlib/meta.py
@@ -47,7 +47,7 @@ class VariantMeta:
     @classmethod
     def from_str(cls, input_str: str) -> Self:
         subpattern = VALIDATION_REGEX[1:-1]  # removing starting `^` and trailing `$`
-        pattern = rf"^(?P<provider>{subpattern}) :: (?P<key>{subpattern}) :: (?P<value>{subpattern})$"  # noqa: E501
+        pattern = rf"^(?P<provider>{subpattern})\s*::\s*(?P<key>{subpattern})\s*::\s*(?P<value>{subpattern})$"  # noqa: E501
 
         # Try matching the input string with the regex pattern
         match = re.match(pattern, input_str.strip())


### PR DESCRIPTION
Allow any (or no) whitespace between `::` separators in `VariantMeta.from_str()`, in order to make it more feasible for parsing user input.  Unless I'm missing something, there should be no need to strictly ensure that input is strictly formatted as `A :: B :: C` (rather than, say, `A::B::C`), as long as we properly format output. This can be especially useful for command-line arguments where spaces would have to be quoted.