### PR TITLE
Abstract away plugin lookup and querying

### DIFF
--- a/tests/test_meta.py
+++ b/tests/test_meta.py
@@ -90,9 +90,16 @@ def test_failing_regex_value():
             _ = VariantMeta(provider="provider", key="key", value=f"val{c}ue")
 
 
-def test_from_str_valid():
+@pytest.mark.parametrize(
+    "input_str",
+    [
+        "OmniCorp :: access_key :: secret_value",
+        "OmniCorp::access_key::secret_value",
+        "OmniCorp ::access_key::     secret_value",
+    ],
+)
+def test_from_str_valid(input_str: str):
     # Test case: Valid string input
-    input_str = "OmniCorp :: access_key :: secret_value"
     variant_meta = VariantMeta.from_str(input_str)
 
     # Check if the resulting object matches the expected values

--- a/variantlib/commands/generate_index_json.py
+++ b/variantlib/commands/generate_index_json.py
@@ -7,7 +7,7 @@ import pathlib
 import zipfile
 
 from variantlib.meta import VariantMeta
-from variantlib.plugins import load_plugins
+from variantlib.plugins import PluginLoader
 
 logger = logging.getLogger(__name__)
 logger.setLevel(logging.INFO)
@@ -75,7 +75,7 @@ def generate_index_json(args):
                     f"{wheel}: different metadata assigned to {variant_hash}"
                 )
 
-    all_plugins = load_plugins().get_dist_name_mapping()
+    all_plugins = PluginLoader.create().get_dist_name_mapping()
     provider_requires = set()
     for provider in known_providers:
         if (plugin := all_plugins.get(provider)) is not None:

--- a/variantlib/meta.py
+++ b/variantlib/meta.py
@@ -47,7 +47,7 @@ class VariantMeta:
     @classmethod
     def from_str(cls, input_str: str) -> Self:
         subpattern = VALIDATION_REGEX[1:-1]  # removing starting `^` and trailing `$`
-        pattern = rf"^(?P<provider>{subpattern}) :: (?P<key>{subpattern}) :: (?P<value>{subpattern})$"  # noqa: E501
+        pattern = rf"^(?P<provider>{subpattern})\s*::\s*(?P<key>{subpattern})\s*::\s*(?P<value>{subpattern})$"  # noqa: E501
 
         # Try matching the input string with the regex pattern
         match = re.match(pattern, input_str.strip())

--- a/variantlib/platform.py
+++ b/variantlib/platform.py
@@ -6,7 +6,7 @@ from typing import TYPE_CHECKING
 
 from variantlib.combination import filtered_sorted_variants
 from variantlib.combination import get_combinations
-from variantlib.plugins import load_plugins
+from variantlib.plugins import PluginLoader
 
 if TYPE_CHECKING:
     from collections.abc import Generator
@@ -32,7 +32,7 @@ class VariantCache:
 
 @VariantCache()
 def _query_variant_plugins() -> dict[str, ProviderConfig]:
-    return load_plugins().get_provider_configs()
+    return PluginLoader.create().get_provider_configs()
 
 
 def get_variant_hashes_by_priority(

--- a/variantlib/plugins.py
+++ b/variantlib/plugins.py
@@ -17,6 +17,14 @@ class PluginLoader:
         self._dist_names = {}
         self._loaded = False
 
+    @cache
+    @staticmethod
+    def create() -> PluginLoader:
+        """Return a cached instance of PluginLoader with plugins loaded"""
+        loader = PluginLoader()
+        loader.load_plugins()
+        return loader
+
     def load_plugins(self) -> None:
         """Find, load and instantiate all plugins"""
 
@@ -82,11 +90,3 @@ class PluginLoader:
         assert self._loaded
 
         return self._dist_names
-
-
-@cache
-def load_plugins() -> PluginLoader:
-    """Return a cached instance of PluginLoader with plugins loaded"""
-    loader = PluginLoader()
-    loader.load_plugins()
-    return loader

--- a/variantlib/plugins.py
+++ b/variantlib/plugins.py
@@ -1,0 +1,92 @@
+from __future__ import annotations
+
+import logging
+from functools import cache
+from importlib.metadata import entry_points
+
+from variantlib.config import ProviderConfig
+
+logger = logging.getLogger(__name__)
+
+
+class PluginLoader:
+    """Load and query plugins"""
+
+    def __init__(self) -> None:
+        self._plugins = {}
+        self._dist_names = {}
+        self._loaded = False
+
+    def load_plugins(self) -> None:
+        """Find, load and instantiate all plugins"""
+
+        logger.info("Discovering Wheel Variant plugins...")
+        plugins = entry_points().select(group="variantlib.plugins")
+
+        # ----------- Checking if two plugins have the same name ----------- #
+        seen = set()
+        duplicates = set()
+
+        for plugin_name in [plugin.name for plugin in plugins]:
+            if plugin_name in seen:
+                duplicates.add(plugin_name)
+            else:
+                seen.add(plugin_name)
+
+        if duplicates:
+            logger.warning(
+                "Duplicate plugins found: %s - Unpredicatable behavior.", duplicates
+            )
+
+        # ---------------------- Querying each plugin ---------------------- #
+        for plugin in plugins:
+            try:
+                logger.info(f"Loading plugin: {plugin.name} - v{plugin.dist.version}")  # noqa: G004
+
+                # Dynamically load the plugin class
+                plugin_class = plugin.load()
+
+                # Instantiate the plugin
+                self._plugins[plugin.name] = plugin_class()
+
+                # Store package distribution names for later use
+                self._dist_names[plugin.name] = plugin.dist.name
+            except Exception:
+                logging.exception("An unknown error happened - Ignoring plugin")
+
+        self._loaded = True
+
+    def get_provider_configs(self) -> dict[str, ProviderConfig]:
+        """Get a mapping of plugin names to provider configs"""
+
+        assert self._loaded
+
+        provider_cfgs = {}
+        for name, plugin_instance in self._plugins.items():
+            provider_cfg = plugin_instance.run()
+
+            if not isinstance(provider_cfg, ProviderConfig):
+                logging.error(
+                    f"Provider: {name} returned an unexpected type: "  # noqa: G004
+                    f"{type(provider_cfg)} - Expected: `ProviderConfig`. Ignoring..."
+                )
+                continue
+
+            provider_cfgs[name] = provider_cfg
+
+        return provider_cfgs
+
+    def get_dist_name_mapping(self) -> dict[str, str]:
+        """Get a mapping from plugin names to distribution names"""
+
+        assert self._loaded
+
+        return self._dist_names
+
+
+@cache
+def load_plugins() -> PluginLoader:
+    """Return a cached instance of PluginLoader with plugins loaded"""
+    loader = PluginLoader()
+    loader.load_plugins()
+    return loader


### PR DESCRIPTION
Add a `PluginLoader` class that handles loading and querying plugins.
This removes some duplicate code, prepares for plugins having more
than one method in the future, and enables using a single cached plugin
list, rather than repeatedly querying and instantiating them.
