### PR TITLE
plugins: Rename `run()` to `get_supported_configs()`, add tests

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -47,6 +47,7 @@ test = [
     "pytest-cov>=5.0.0,<6.0.0",
     "pytest-dotenv>=0.5.0,<1.0.0",
     "pytest-env>=1.1.3,<2.0.0",
+    "pytest-mock>=3.14.0,<4.0.0",
     "pytest-runner>=6.0.0,<7.0.0",
     "pytest-ordering>=0.6,<1.0.0",
     "parameterized>=0.9.0,<0.10",

--- a/tests/test_plugins.py
+++ b/tests/test_plugins.py
@@ -1,0 +1,102 @@
+from dataclasses import dataclass
+from typing import Any, Optional
+
+import pytest
+
+from variantlib.config import KeyConfig,ProviderConfig
+from variantlib.plugins import PluginLoader
+
+
+class MockedPluginA:
+    def get_supported_configs(self) -> Optional[ProviderConfig]:
+        return ProviderConfig(
+            provider="test_plugin",
+            configs=[
+                KeyConfig("key1", ["val1a", "val1b"]),
+                KeyConfig("key2", ["val2a", "val2b", "val2c"]),
+            ],
+        )
+
+
+class MockedPluginB:
+    def get_supported_configs(self) -> Optional[ProviderConfig]:
+        return ProviderConfig(
+            provider="second_plugin",
+            configs=[
+                KeyConfig("key3", ["val3a"]),
+            ],
+        )
+
+
+class MockedPluginC:
+    def get_supported_configs(self) -> Optional[ProviderConfig]:
+        return None
+
+
+@dataclass
+class MockedDistribution:
+    name: str
+    version: str
+
+
+@dataclass
+class MockedEntryPoint:
+    name: Optional[str]
+    value: str
+    plugin: Any
+    group: Optional[str] = None
+    dist: Optional[MockedDistribution] = None
+
+    def load(self) -> Any:
+        return self.plugin
+
+
+@pytest.fixture(scope="session")
+def mocked_plugin_loader(session_mocker):
+    session_mocker.patch("variantlib.plugins.entry_points")().select.return_value = [
+        MockedEntryPoint(
+            name="test_plugin",
+            value="tests.test_plugins:MockedPluginA",
+            dist=MockedDistribution(name="test-plugin", version="1.2.3"),
+            plugin=MockedPluginA,
+        ),
+        MockedEntryPoint(
+            name="other_plugin",
+            value="tests.test_plugins:MockedPluginB",
+            dist=MockedDistribution(name="other-plugin", version="4.5.6"),
+            plugin=MockedPluginB,
+        ),
+        MockedEntryPoint(
+            name="incompatible_plugin",
+            value="tests.test_plugins:MockedPluginC",
+            dist=MockedDistribution(name="incompatible-plugin", version="0.0.0"),
+            plugin=MockedPluginC,
+        ),
+    ]
+    yield PluginLoader()
+
+
+def test_get_supported_configs(mocked_plugin_loader):
+    assert mocked_plugin_loader.get_supported_configs() == {
+        "other_plugin": ProviderConfig(
+            provider="second_plugin",
+            configs=[
+                KeyConfig("key3", ["val3a"]),
+            ],
+        ),
+        "test_plugin": ProviderConfig(
+            provider="test_plugin",
+            configs=[
+                KeyConfig("key1", ["val1a", "val1b"]),
+                KeyConfig("key2", ["val2a", "val2b", "val2c"]),
+            ],
+        ),
+    }
+
+
+def test_get_dist_name_mapping(mocked_plugin_loader):
+    assert mocked_plugin_loader.get_dist_name_mapping() == {
+        "incompatible_plugin": "incompatible-plugin",
+        "other_plugin": "other-plugin",
+        "test_plugin": "test-plugin",
+    }

--- a/variantlib/platform.py
+++ b/variantlib/platform.py
@@ -34,7 +34,7 @@ class VariantCache:
 
 @VariantCache()
 def _query_variant_plugins() -> dict[str, ProviderConfig]:
-    return PluginLoader().get_provider_configs()
+    return PluginLoader().get_supported_configs()
 
 
 def get_variant_hashes_by_priority(

--- a/variantlib/plugins.py
+++ b/variantlib/plugins.py
@@ -1,7 +1,6 @@
 from __future__ import annotations
 
 import logging
-from functools import cache
 from importlib.metadata import entry_points
 
 from variantlib.config import ProviderConfig
@@ -10,14 +9,13 @@ from variantlib.metaclasses import SingletonMetaClass
 logger = logging.getLogger(__name__)
 
 
-class PluginLoader(metaclass=SingletonMeta):
+class PluginLoader(metaclass=SingletonMetaClass):
     """Load and query plugins"""
 
     def __init__(self) -> None:
         self._plugins = {}
         self._dist_names = {}
-
-        load_plugins()
+        self.load_plugins()
 
     def load_plugins(self) -> None:
         """Find, load and instantiate all plugins"""
@@ -56,12 +54,12 @@ class PluginLoader(metaclass=SingletonMeta):
             except Exception:
                 logging.exception("An unknown error happened - Ignoring plugin")
 
-    def get_provider_configs(self) -> dict[str, ProviderConfig]:
+    def get_supported_configs(self) -> dict[str, ProviderConfig]:
         """Get a mapping of plugin names to provider configs"""
 
         provider_cfgs = {}
         for name, plugin_instance in self._plugins.items():
-            provider_cfg = plugin_instance.run()
+            provider_cfg = plugin_instance.get_supported_configs()
 
             if not isinstance(provider_cfg, ProviderConfig):
                 logging.error(


### PR DESCRIPTION
Rename the `run()` API to `get_supported_configs()`, to prepare for adding other plugin methods.  Fix bugs introduced while introducing the singleton pattern.  Add tests.