### PR TITLE
Add an API to describe variant using labels

### DIFF
--- a/tests/test_plugins.py
+++ b/tests/test_plugins.py
@@ -61,6 +61,13 @@ class MockedPluginC(PluginBase):
         return ret
 
 
+class MockedPluginD:
+    namespace = "plugin_without_labels"
+
+    def get_supported_configs(self) -> Optional[ProviderConfig]:
+        return None
+
+
 class ClashingPlugin(PluginBase):
     namespace = "test_plugin"
 
@@ -112,6 +119,11 @@ def mocked_plugin_loader(session_mocker):
             name="incompatible_plugin",
             value="tests.test_plugins:MockedPluginC",
             plugin=MockedPluginC,
+        ),
+        MockedEntryPoint(
+            name="no_labels",
+            value="tests.test_plugins:MockedPluginD",
+            plugin=MockedPluginD,
         ),
     ]
     yield PluginLoader()

--- a/variantlib/base.py
+++ b/variantlib/base.py
@@ -2,6 +2,7 @@ from abc import ABC, abstractmethod, abstractproperty
 from typing import Protocol, runtime_checkable
 
 from variantlib.config import ProviderConfig
+from variantlib.meta import VariantDescription
 
 
 @runtime_checkable
@@ -17,6 +18,10 @@ class PluginType(Protocol):
         """Get supported configs for the current system"""
         ...
 
+    def get_variant_labels(self, variant_desc: VariantDescription) -> list[str]:
+        """Get list of short labels to describe the variant"""
+        ...
+
 
 class PluginBase(ABC):
     """An abstract base class that can be used to implement plugins"""
@@ -26,3 +31,6 @@ class PluginBase(ABC):
 
     @abstractmethod
     def get_supported_configs(self) -> ProviderConfig: ...
+
+    def get_variant_labels(self, variant_desc: VariantDescription) -> list[str]:
+        return []

--- a/variantlib/base.py
+++ b/variantlib/base.py
@@ -5,7 +5,6 @@ from variantlib.config import ProviderConfig
 from variantlib.meta import VariantDescription
 
 
-@runtime_checkable
 class PluginType(Protocol):
     """A protocol for plugin classes"""
 

--- a/variantlib/plugins.py
+++ b/variantlib/plugins.py
@@ -92,3 +92,12 @@ class PluginLoader(metaclass=SingletonMetaClass):
         """Get a mapping from plugin names to distribution names"""
 
         return self._dist_names
+
+    def get_variant_labels(self, variant_desc: VariantDescription) -> list[str]:
+        """Get list of short labels to describe the variant"""
+
+        labels = []
+        for plugin in self._plugins.values():
+            labels += plugin.get_variant_labels(variant_desc)
+
+        return labels

--- a/variantlib/plugins.py
+++ b/variantlib/plugins.py
@@ -44,7 +44,12 @@ class PluginLoader(metaclass=SingletonMetaClass):
 
                 # Instantiate the plugin
                 plugin_instance = plugin_class()
-                assert isinstance(plugin_instance, PluginType)
+
+                # Check for obligatory members
+                for attr in ("namespace", "get_supported_configs"):
+                    assert hasattr(
+                        plugin_instance, attr
+                    ), f"Plugin is missing required member: {attr}"
             except Exception:
                 logging.exception("An unknown error happened - Ignoring plugin")
             else:
@@ -98,6 +103,7 @@ class PluginLoader(metaclass=SingletonMetaClass):
 
         labels = []
         for plugin in self._plugins.values():
-            labels += plugin.get_variant_labels(variant_desc)
+            if hasattr(plugin, "get_variant_labels"):
+                labels += plugin.get_variant_labels(variant_desc)
 
         return labels


### PR DESCRIPTION
Add a minimal API that lets plugins process the variant description and add short labels that could be used to describe the wheel. The labels are entirely optional -- plugins may not return any, and clients may ignore them.  The design also assumes that the client is responsible for choosing how many labels to use before truncating -- though I suppose I'll add a helper function to `variantlib` for that purpose.

The design assumes that plugin get complete unfiltered `VariantDescription` -- and therefore also see variant metadata from other plugins.  I don't think that's really a problem, though it assumes that the plugin must compare both against provider and key names.

At this point, the protocol makes the API mandatory, even if it would only return an empty list unconditionally.  Perhaps we should make the function optional somehow instead.