### PR TITLE
plugins: Add a public `name` property and use it as primary identifier

### DIFF
--- a/tests/artifacts/expected.json
+++ b/tests/artifacts/expected.json
@@ -1,783 +1,783 @@
 [
     [
         {
-            "provider": "custom_hw",
+            "namespace": "custom_hw",
             "key": "driver_version",
             "value": "1.3"
         },
         {
-            "provider": "custom_hw",
+            "namespace": "custom_hw",
             "key": "hw_architecture",
             "value": "3.4"
         },
         {
-            "provider": "networking",
+            "namespace": "networking",
             "key": "speed",
             "value": "10GBPS"
         }
     ],
     [
         {
-            "provider": "custom_hw",
+            "namespace": "custom_hw",
             "key": "driver_version",
             "value": "1.3"
         },
         {
-            "provider": "custom_hw",
+            "namespace": "custom_hw",
             "key": "hw_architecture",
             "value": "3.4"
         },
         {
-            "provider": "networking",
+            "namespace": "networking",
             "key": "speed",
             "value": "1GBPS"
         }
     ],
     [
         {
-            "provider": "custom_hw",
+            "namespace": "custom_hw",
             "key": "driver_version",
             "value": "1.3"
         },
         {
-            "provider": "custom_hw",
+            "namespace": "custom_hw",
             "key": "hw_architecture",
             "value": "3.4"
         },
         {
-            "provider": "networking",
+            "namespace": "networking",
             "key": "speed",
             "value": "100MBPS"
         }
     ],
     [
         {
-            "provider": "custom_hw",
+            "namespace": "custom_hw",
             "key": "driver_version",
             "value": "1.3"
         },
         {
-            "provider": "custom_hw",
+            "namespace": "custom_hw",
             "key": "hw_architecture",
             "value": "3"
         },
         {
-            "provider": "networking",
+            "namespace": "networking",
             "key": "speed",
             "value": "10GBPS"
         }
     ],
     [
         {
-            "provider": "custom_hw",
+            "namespace": "custom_hw",
             "key": "driver_version",
             "value": "1.3"
         },
         {
-            "provider": "custom_hw",
+            "namespace": "custom_hw",
             "key": "hw_architecture",
             "value": "3"
         },
         {
-            "provider": "networking",
+            "namespace": "networking",
             "key": "speed",
             "value": "1GBPS"
         }
     ],
     [
         {
-            "provider": "custom_hw",
+            "namespace": "custom_hw",
             "key": "driver_version",
             "value": "1.3"
         },
         {
-            "provider": "custom_hw",
+            "namespace": "custom_hw",
             "key": "hw_architecture",
             "value": "3"
         },
         {
-            "provider": "networking",
+            "namespace": "networking",
             "key": "speed",
             "value": "100MBPS"
         }
     ],
     [
         {
-            "provider": "custom_hw",
+            "namespace": "custom_hw",
             "key": "driver_version",
             "value": "1.2"
         },
         {
-            "provider": "custom_hw",
+            "namespace": "custom_hw",
             "key": "hw_architecture",
             "value": "3.4"
         },
         {
-            "provider": "networking",
+            "namespace": "networking",
             "key": "speed",
             "value": "10GBPS"
         }
     ],
     [
         {
-            "provider": "custom_hw",
+            "namespace": "custom_hw",
             "key": "driver_version",
             "value": "1.2"
         },
         {
-            "provider": "custom_hw",
+            "namespace": "custom_hw",
             "key": "hw_architecture",
             "value": "3.4"
         },
         {
-            "provider": "networking",
+            "namespace": "networking",
             "key": "speed",
             "value": "1GBPS"
         }
     ],
     [
         {
-            "provider": "custom_hw",
+            "namespace": "custom_hw",
             "key": "driver_version",
             "value": "1.2"
         },
         {
-            "provider": "custom_hw",
+            "namespace": "custom_hw",
             "key": "hw_architecture",
             "value": "3.4"
         },
         {
-            "provider": "networking",
+            "namespace": "networking",
             "key": "speed",
             "value": "100MBPS"
         }
     ],
     [
         {
-            "provider": "custom_hw",
+            "namespace": "custom_hw",
             "key": "driver_version",
             "value": "1.2"
         },
         {
-            "provider": "custom_hw",
+            "namespace": "custom_hw",
             "key": "hw_architecture",
             "value": "3"
         },
         {
-            "provider": "networking",
+            "namespace": "networking",
             "key": "speed",
             "value": "10GBPS"
         }
     ],
     [
         {
-            "provider": "custom_hw",
+            "namespace": "custom_hw",
             "key": "driver_version",
             "value": "1.2"
         },
         {
-            "provider": "custom_hw",
+            "namespace": "custom_hw",
             "key": "hw_architecture",
             "value": "3"
         },
         {
-            "provider": "networking",
+            "namespace": "networking",
             "key": "speed",
             "value": "1GBPS"
         }
     ],
     [
         {
-            "provider": "custom_hw",
+            "namespace": "custom_hw",
             "key": "driver_version",
             "value": "1.2"
         },
         {
-            "provider": "custom_hw",
+            "namespace": "custom_hw",
             "key": "hw_architecture",
             "value": "3"
         },
         {
-            "provider": "networking",
+            "namespace": "networking",
             "key": "speed",
             "value": "100MBPS"
         }
     ],
     [
         {
-            "provider": "custom_hw",
+            "namespace": "custom_hw",
             "key": "driver_version",
             "value": "1.1"
         },
         {
-            "provider": "custom_hw",
+            "namespace": "custom_hw",
             "key": "hw_architecture",
             "value": "3.4"
         },
         {
-            "provider": "networking",
+            "namespace": "networking",
             "key": "speed",
             "value": "10GBPS"
         }
     ],
     [
         {
-            "provider": "custom_hw",
+            "namespace": "custom_hw",
             "key": "driver_version",
             "value": "1.1"
         },
         {
-            "provider": "custom_hw",
+            "namespace": "custom_hw",
             "key": "hw_architecture",
             "value": "3.4"
         },
         {
-            "provider": "networking",
+            "namespace": "networking",
             "key": "speed",
             "value": "1GBPS"
         }
     ],
     [
         {
-            "provider": "custom_hw",
+            "namespace": "custom_hw",
             "key": "driver_version",
             "value": "1.1"
         },
         {
-            "provider": "custom_hw",
+            "namespace": "custom_hw",
             "key": "hw_architecture",
             "value": "3.4"
         },
         {
-            "provider": "networking",
+            "namespace": "networking",
             "key": "speed",
             "value": "100MBPS"
         }
     ],
     [
         {
-            "provider": "custom_hw",
+            "namespace": "custom_hw",
             "key": "driver_version",
             "value": "1.1"
         },
         {
-            "provider": "custom_hw",
+            "namespace": "custom_hw",
             "key": "hw_architecture",
             "value": "3"
         },
         {
-            "provider": "networking",
+            "namespace": "networking",
             "key": "speed",
             "value": "10GBPS"
         }
     ],
     [
         {
-            "provider": "custom_hw",
+            "namespace": "custom_hw",
             "key": "driver_version",
             "value": "1.1"
         },
         {
-            "provider": "custom_hw",
+            "namespace": "custom_hw",
             "key": "hw_architecture",
             "value": "3"
         },
         {
-            "provider": "networking",
+            "namespace": "networking",
             "key": "speed",
             "value": "1GBPS"
         }
     ],
     [
         {
-            "provider": "custom_hw",
+            "namespace": "custom_hw",
             "key": "driver_version",
             "value": "1.1"
         },
         {
-            "provider": "custom_hw",
+            "namespace": "custom_hw",
             "key": "hw_architecture",
             "value": "3"
         },
         {
-            "provider": "networking",
+            "namespace": "networking",
             "key": "speed",
             "value": "100MBPS"
         }
     ],
     [
         {
-            "provider": "custom_hw",
+            "namespace": "custom_hw",
             "key": "driver_version",
             "value": "1"
         },
         {
-            "provider": "custom_hw",
+            "namespace": "custom_hw",
             "key": "hw_architecture",
             "value": "3.4"
         },
         {
-            "provider": "networking",
+            "namespace": "networking",
             "key": "speed",
             "value": "10GBPS"
         }
     ],
     [
         {
-            "provider": "custom_hw",
+            "namespace": "custom_hw",
             "key": "driver_version",
             "value": "1"
         },
         {
-            "provider": "custom_hw",
+            "namespace": "custom_hw",
             "key": "hw_architecture",
             "value": "3.4"
         },
         {
-            "provider": "networking",
+            "namespace": "networking",
             "key": "speed",
             "value": "1GBPS"
         }
     ],
     [
         {
-            "provider": "custom_hw",
+            "namespace": "custom_hw",
             "key": "driver_version",
             "value": "1"
         },
         {
-            "provider": "custom_hw",
+            "namespace": "custom_hw",
             "key": "hw_architecture",
             "value": "3.4"
         },
         {
-            "provider": "networking",
+            "namespace": "networking",
             "key": "speed",
             "value": "100MBPS"
         }
     ],
     [
         {
-            "provider": "custom_hw",
+            "namespace": "custom_hw",
             "key": "driver_version",
             "value": "1"
         },
         {
-            "provider": "custom_hw",
+            "namespace": "custom_hw",
             "key": "hw_architecture",
             "value": "3"
         },
         {
-            "provider": "networking",
+            "namespace": "networking",
             "key": "speed",
             "value": "10GBPS"
         }
     ],
     [
         {
-            "provider": "custom_hw",
+            "namespace": "custom_hw",
             "key": "driver_version",
             "value": "1"
         },
         {
-            "provider": "custom_hw",
+            "namespace": "custom_hw",
             "key": "hw_architecture",
             "value": "3"
         },
         {
-            "provider": "networking",
+            "namespace": "networking",
             "key": "speed",
             "value": "1GBPS"
         }
     ],
     [
         {
-            "provider": "custom_hw",
+            "namespace": "custom_hw",
             "key": "driver_version",
             "value": "1"
         },
         {
-            "provider": "custom_hw",
+            "namespace": "custom_hw",
             "key": "hw_architecture",
             "value": "3"
         },
         {
-            "provider": "networking",
+            "namespace": "networking",
             "key": "speed",
             "value": "100MBPS"
         }
     ],
     [
         {
-            "provider": "custom_hw",
+            "namespace": "custom_hw",
             "key": "driver_version",
             "value": "1.3"
         },
         {
-            "provider": "custom_hw",
+            "namespace": "custom_hw",
             "key": "hw_architecture",
             "value": "3.4"
         }
     ],
     [
         {
-            "provider": "custom_hw",
+            "namespace": "custom_hw",
             "key": "driver_version",
             "value": "1.3"
         },
         {
-            "provider": "custom_hw",
+            "namespace": "custom_hw",
             "key": "hw_architecture",
             "value": "3"
         }
     ],
     [
         {
-            "provider": "custom_hw",
+            "namespace": "custom_hw",
             "key": "driver_version",
             "value": "1.2"
         },
         {
-            "provider": "custom_hw",
+            "namespace": "custom_hw",
             "key": "hw_architecture",
             "value": "3.4"
         }
     ],
     [
         {
-            "provider": "custom_hw",
+            "namespace": "custom_hw",
             "key": "driver_version",
             "value": "1.2"
         },
         {
-            "provider": "custom_hw",
+            "namespace": "custom_hw",
             "key": "hw_architecture",
             "value": "3"
         }
     ],
     [
         {
-            "provider": "custom_hw",
+            "namespace": "custom_hw",
             "key": "driver_version",
             "value": "1.1"
         },
         {
-            "provider": "custom_hw",
+            "namespace": "custom_hw",
             "key": "hw_architecture",
             "value": "3.4"
         }
     ],
     [
         {
-            "provider": "custom_hw",
+            "namespace": "custom_hw",
             "key": "driver_version",
             "value": "1.1"
         },
         {
-            "provider": "custom_hw",
+            "namespace": "custom_hw",
             "key": "hw_architecture",
             "value": "3"
         }
     ],
     [
         {
-            "provider": "custom_hw",
+            "namespace": "custom_hw",
             "key": "driver_version",
             "value": "1"
         },
         {
-            "provider": "custom_hw",
+            "namespace": "custom_hw",
             "key": "hw_architecture",
             "value": "3.4"
         }
     ],
     [
         {
-            "provider": "custom_hw",
+            "namespace": "custom_hw",
             "key": "driver_version",
             "value": "1"
         },
         {
-            "provider": "custom_hw",
+            "namespace": "custom_hw",
             "key": "hw_architecture",
             "value": "3"
         }
     ],
     [
         {
-            "provider": "custom_hw",
+            "namespace": "custom_hw",
             "key": "driver_version",
             "value": "1.3"
         },
         {
-            "provider": "networking",
+            "namespace": "networking",
             "key": "speed",
             "value": "10GBPS"
         }
     ],
     [
         {
-            "provider": "custom_hw",
+            "namespace": "custom_hw",
             "key": "driver_version",
             "value": "1.3"
         },
         {
-            "provider": "networking",
+            "namespace": "networking",
             "key": "speed",
             "value": "1GBPS"
         }
     ],
     [
         {
-            "provider": "custom_hw",
+            "namespace": "custom_hw",
             "key": "driver_version",
             "value": "1.3"
         },
         {
-            "provider": "networking",
+            "namespace": "networking",
             "key": "speed",
             "value": "100MBPS"
         }
     ],
     [
         {
-            "provider": "custom_hw",
+            "namespace": "custom_hw",
             "key": "driver_version",
             "value": "1.2"
         },
         {
-            "provider": "networking",
+            "namespace": "networking",
             "key": "speed",
             "value": "10GBPS"
         }
     ],
     [
         {
-            "provider": "custom_hw",
+            "namespace": "custom_hw",
             "key": "driver_version",
             "value": "1.2"
         },
         {
-            "provider": "networking",
+            "namespace": "networking",
             "key": "speed",
             "value": "1GBPS"
         }
     ],
     [
         {
-            "provider": "custom_hw",
+            "namespace": "custom_hw",
             "key": "driver_version",
             "value": "1.2"
         },
         {
-            "provider": "networking",
+            "namespace": "networking",
             "key": "speed",
             "value": "100MBPS"
         }
     ],
     [
         {
-            "provider": "custom_hw",
+            "namespace": "custom_hw",
             "key": "driver_version",
             "value": "1.1"
         },
         {
-            "provider": "networking",
+            "namespace": "networking",
             "key": "speed",
             "value": "10GBPS"
         }
     ],
     [
         {
-            "provider": "custom_hw",
+            "namespace": "custom_hw",
             "key": "driver_version",
             "value": "1.1"
         },
         {
-            "provider": "networking",
+            "namespace": "networking",
             "key": "speed",
             "value": "1GBPS"
         }
     ],
     [
         {
-            "provider": "custom_hw",
+            "namespace": "custom_hw",
             "key": "driver_version",
             "value": "1.1"
         },
         {
-            "provider": "networking",
+            "namespace": "networking",
             "key": "speed",
             "value": "100MBPS"
         }
     ],
     [
         {
-            "provider": "custom_hw",
+            "namespace": "custom_hw",
             "key": "driver_version",
             "value": "1"
         },
         {
-            "provider": "networking",
+            "namespace": "networking",
             "key": "speed",
             "value": "10GBPS"
         }
     ],
     [
         {
-            "provider": "custom_hw",
+            "namespace": "custom_hw",
             "key": "driver_version",
             "value": "1"
         },
         {
-            "provider": "networking",
+            "namespace": "networking",
             "key": "speed",
             "value": "1GBPS"
         }
     ],
     [
         {
-            "provider": "custom_hw",
+            "namespace": "custom_hw",
             "key": "driver_version",
             "value": "1"
         },
         {
-            "provider": "networking",
+            "namespace": "networking",
             "key": "speed",
             "value": "100MBPS"
         }
     ],
     [
         {
-            "provider": "custom_hw",
+            "namespace": "custom_hw",
             "key": "hw_architecture",
             "value": "3.4"
         },
         {
-            "provider": "networking",
+            "namespace": "networking",
             "key": "speed",
             "value": "10GBPS"
         }
     ],
     [
         {
-            "provider": "custom_hw",
+            "namespace": "custom_hw",
             "key": "hw_architecture",
             "value": "3.4"
         },
         {
-            "provider": "networking",
+            "namespace": "networking",
             "key": "speed",
             "value": "1GBPS"
         }
     ],
     [
         {
-            "provider": "custom_hw",
+            "namespace": "custom_hw",
             "key": "hw_architecture",
             "value": "3.4"
         },
         {
-            "provider": "networking",
+            "namespace": "networking",
             "key": "speed",
             "value": "100MBPS"
         }
     ],
     [
         {
-            "provider": "custom_hw",
+            "namespace": "custom_hw",
             "key": "hw_architecture",
             "value": "3"
         },
         {
-            "provider": "networking",
+            "namespace": "networking",
             "key": "speed",
             "value": "10GBPS"
         }
     ],
     [
         {
-            "provider": "custom_hw",
+            "namespace": "custom_hw",
             "key": "hw_architecture",
             "value": "3"
         },
         {
-            "provider": "networking",
+            "namespace": "networking",
             "key": "speed",
             "value": "1GBPS"
         }
     ],
     [
         {
-            "provider": "custom_hw",
+            "namespace": "custom_hw",
             "key": "hw_architecture",
             "value": "3"
         },
         {
-            "provider": "networking",
+            "namespace": "networking",
             "key": "speed",
             "value": "100MBPS"
         }
     ],
     [
         {
-            "provider": "custom_hw",
+            "namespace": "custom_hw",
             "key": "driver_version",
             "value": "1.3"
         }
     ],
     [
         {
-            "provider": "custom_hw",
+            "namespace": "custom_hw",
             "key": "driver_version",
             "value": "1.2"
         }
     ],
     [
         {
-            "provider": "custom_hw",
+            "namespace": "custom_hw",
             "key": "driver_version",
             "value": "1.1"
         }
     ],
     [
         {
-            "provider": "custom_hw",
+            "namespace": "custom_hw",
             "key": "driver_version",
             "value": "1"
         }
     ],
     [
         {
-            "provider": "custom_hw",
+            "namespace": "custom_hw",
             "key": "hw_architecture",
             "value": "3.4"
         }
     ],
     [
         {
-            "provider": "custom_hw",
+            "namespace": "custom_hw",
             "key": "hw_architecture",
             "value": "3"
         }
     ],
     [
         {
-            "provider": "networking",
+            "namespace": "networking",
             "key": "speed",
             "value": "10GBPS"
         }
     ],
     [
         {
-            "provider": "networking",
+            "namespace": "networking",
             "key": "speed",
             "value": "1GBPS"
         }
     ],
     [
         {
-            "provider": "networking",
+            "namespace": "networking",
             "key": "speed",
             "value": "100MBPS"
         }

--- a/tests/test_combinations.py
+++ b/tests/test_combinations.py
@@ -21,7 +21,7 @@ from variantlib.meta import VariantDescription
 @pytest.fixture(scope="session")
 def configs():
     config_custom_hw = ProviderConfig(
-        provider="custom_hw",
+        namespace="custom_hw",
         configs=[
             KeyConfig(key="driver_version", values=["1.3", "1.2", "1.1", "1"]),
             KeyConfig(key="hw_architecture", values=["3.4", "3"]),
@@ -29,7 +29,7 @@ def configs():
     )
 
     config_networking = ProviderConfig(
-        provider="networking",
+        namespace="networking",
         configs=[
             KeyConfig(key="speed", values=["10GBPS", "1GBPS", "100MBPS"]),
         ],
@@ -59,7 +59,7 @@ def desc_to_json(desc_list: list[VariantDescription]) -> Generator:
     for desc in shuffled_desc_list:
         variant_dict = {}
         for variant_meta in desc:
-            provider_dict = variant_dict.setdefault(variant_meta.provider, {})
+            provider_dict = variant_dict.setdefault(variant_meta.namespace, {})
             provider_dict[variant_meta.key] = variant_meta.value
         yield (desc.hexdigest, variant_dict)
 
@@ -75,24 +75,24 @@ def test_filtered_sorted_variants_roundtrip(configs):
 @example(
     [
         ProviderConfig(
-            provider="A",
+            namespace="A",
             configs=[
                 KeyConfig(key="A1", values=["x"]),
                 KeyConfig(key="A2", values=["x"]),
             ],
         ),
-        ProviderConfig(provider="B", configs=[KeyConfig(key="B1", values=["x"])]),
-        ProviderConfig(provider="C", configs=[KeyConfig(key="C1", values=["x"])]),
+        ProviderConfig(namespace="B", configs=[KeyConfig(key="B1", values=["x"])]),
+        ProviderConfig(namespace="C", configs=[KeyConfig(key="C1", values=["x"])]),
     ]
 )
 @given(
     st.lists(
         min_size=1,
         max_size=3,
-        unique_by=lambda provider_cfg: provider_cfg.provider,
+        unique_by=lambda provider_cfg: provider_cfg.namespace,
         elements=st.builds(
             ProviderConfig,
-            provider=st.text(
+            namespace=st.text(
                 string.ascii_letters + string.digits + "_", min_size=1, max_size=64
             ),
             configs=st.lists(

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -16,10 +16,10 @@ def test_provider_config_creation_valid():
     key_config_1 = KeyConfig(key="attr_nameA", values=["7", "4", "8", "12"])
     key_config_2 = KeyConfig(key="attr_nameB", values=["3", "7", "2", "18", "22"])
     provider_config = ProviderConfig(
-        provider="provider_name", configs=[key_config_1, key_config_2]
+        namespace="provider_name", configs=[key_config_1, key_config_2]
     )
 
-    assert provider_config.provider == "provider_name"
+    assert provider_config.namespace == "provider_name"
     assert len(provider_config.configs) == 2
     assert provider_config.configs[0].key == "attr_nameA"
     assert provider_config.configs[1].key == "attr_nameB"
@@ -33,7 +33,7 @@ def test_duplicate_key_config():
     with pytest.raises(
         ValueError, match="Duplicate `KeyConfig` for key='attr_nameA' found."
     ):
-        ProviderConfig(provider="provider_name", configs=[key_config_1, key_config_2])
+        ProviderConfig(namespace="provider_name", configs=[key_config_1, key_config_2])
 
 
 def test_empty_values_list_in_key_config():
@@ -69,11 +69,11 @@ def test_invalid_values_type_in_key_config():
         )  # Expecting a list for `values`
 
 
-def test_provider_config_invalid_provider_type():
-    """Test that an invalid provider type raises a validation error."""
+def test_provider_config_invalid_namespace_type():
+    """Test that an invalid namespace type raises a validation error."""
     with pytest.raises(TypeError):
         ProviderConfig(
-            provider=1,
+            namespace=1,
             configs=[KeyConfig(key="attr_nameA", values=["7", "4", "8", "12"])],
         )
 
@@ -81,14 +81,14 @@ def test_provider_config_invalid_provider_type():
 def test_provider_config_invalid_configs_type():
     """Test that an invalid configs type raises a validation error."""
     with pytest.raises(TypeError):
-        ProviderConfig(provider="provider_name", configs="not_a_list_of_key_configs")
+        ProviderConfig(namespace="provider_name", configs="not_a_list_of_key_configs")
 
 
 def test_provider_config_invalid_key_type_in_configs():
     """Test that invalid `KeyConfig` inside `ProviderConfig` raises an error."""
     with pytest.raises(TypeError):
         ProviderConfig(
-            provider="provider_name",
+            namespace="provider_name",
             configs=[{"key": "attr_nameA", "values": ["7", "4", "8", "12"]}],
         )
 
@@ -96,7 +96,7 @@ def test_provider_config_invalid_key_type_in_configs():
 def test_empty_provider_config():
     """Test creation of ProviderConfig with an empty list of KeyConfigs."""
     with pytest.raises(AssertionError):
-        _ = ProviderConfig(provider="provider_name", configs=[])
+        _ = ProviderConfig(namespace="provider_name", configs=[])
 
 
 def test_provider_config_invalid_key_config_type():
@@ -105,7 +105,7 @@ def test_provider_config_invalid_key_config_type():
 
     with pytest.raises(TypeError):
         ProviderConfig(
-            provider="provider_name",
+            namespace="provider_name",
             configs=[
                 KeyConfig(key="attr_nameA", values=["7", "4", "8", "12"]),
                 SimpleNamespace(key=1, values=["1", "2"]),
@@ -130,11 +130,11 @@ def test_provider_config_repr():
     key_config_1 = KeyConfig(key="attr_nameA", values=["7", "4", "8", "12"])
     key_config_2 = KeyConfig(key="attr_nameB", values=["3", "7", "2", "18", "22"])
     provider_config = ProviderConfig(
-        provider="provider_name", configs=[key_config_1, key_config_2]
+        namespace="provider_name", configs=[key_config_1, key_config_2]
     )
 
     expected_repr = (
-        "ProviderConfig(provider='provider_name', "
+        "ProviderConfig(namespace='provider_name', "
         "configs=[KeyConfig(key='attr_nameA', values=['7', '4', '8', '12']), "
         "KeyConfig(key='attr_nameB', values=['3', '7', '2', '18', '22'])])"
     )

--- a/tests/test_meta.py
+++ b/tests/test_meta.py
@@ -16,9 +16,9 @@ from variantlib.meta import VariantMeta
 def test_variantmeta_initialization():
     # Valid initialization
     valid_variant = VariantMeta(
-        provider="OmniCorp", key="access_key", value="secret_value"
+        namespace="OmniCorp", key="access_key", value="secret_value"
     )
-    assert valid_variant.provider == "OmniCorp"
+    assert valid_variant.namespace == "OmniCorp"
     assert valid_variant.key == "access_key"
     assert valid_variant.value == "secret_value"
 
@@ -26,69 +26,69 @@ def test_variantmeta_initialization():
 def test_variantmeta_invalid_type():
     # Invalid initialization for provider (should raise TypeError)
     with pytest.raises(TypeError):
-        VariantMeta(provider="OmniCorp", key="access_key", value=123)
+        VariantMeta(namespace="OmniCorp", key="access_key", value=123)
 
     # Invalid initialization for key (should raise TypeError)
     with pytest.raises(TypeError):
-        VariantMeta(provider="OmniCorp", key=123, value="secret_value")
+        VariantMeta(namespace="OmniCorp", key=123, value="secret_value")
 
     # Invalid initialization for value (should raise TypeError)
     with pytest.raises(TypeError):
-        VariantMeta(provider="OmniCorp", key="access_key", value=123)
+        VariantMeta(namespace="OmniCorp", key="access_key", value=123)
 
 
 def test_variantmeta_data():
     # Test the repr method of VariantMeta
-    vmeta = VariantMeta(provider="OmniCorp", key="access_key", value="secret_value")
+    vmeta = VariantMeta(namespace="OmniCorp", key="access_key", value="secret_value")
     expected_data = "OmniCorp :: access_key :: secret_value"
     assert vmeta.to_str() == expected_data
 
 
 def test_variantmeta_hash():
     # Test the hashing functionality of VariantMeta
-    variant1 = VariantMeta(provider="OmniCorp", key="access_key", value="secret_value")
-    variant2 = VariantMeta(provider="OmniCorp", key="access_key", value="secret_value")
+    variant1 = VariantMeta(namespace="OmniCorp", key="access_key", value="secret_value")
+    variant2 = VariantMeta(namespace="OmniCorp", key="access_key", value="secret_value")
     assert hash(variant1) == hash(variant2)
 
-    # Different value, same provider and key. Should also result in identical hash
+    # Different value, same namespace and key. Should also result in identical hash
     variant3 = VariantMeta(
-        provider="OmniCorp", key="access_key", value="different_value"
+        namespace="OmniCorp", key="access_key", value="different_value"
     )
     assert hash(variant1) == hash(variant3)
 
 
 def test_variantmeta_val_property():
     # Test the val property
-    vmeta = VariantMeta(provider="OmniCorp", key="access_key", value="secret_value")
+    vmeta = VariantMeta(namespace="OmniCorp", key="access_key", value="secret_value")
     expected_val = "OmniCorp :: access_key :: secret_value"
     assert vmeta.to_str() == expected_val
 
 
-def test_failing_regex_provider():
+def test_failing_regex_namespace():
     with pytest.raises(ValueError, match="must match regex"):
-        _ = VariantMeta(provider="", key="key", value="value")
+        _ = VariantMeta(namespace="", key="key", value="value")
 
     for c in "@#$%&*^()[]?.!-{}[]\\/ ":
         with pytest.raises(ValueError, match="must match regex"):
-            _ = VariantMeta(provider=f"Omni{c}Corp", key="key", value="value")
+            _ = VariantMeta(namespace=f"Omni{c}Corp", key="key", value="value")
 
 
 def test_failing_regex_key():
     with pytest.raises(ValueError, match="must match regex"):
-        _ = VariantMeta(provider="provider", key="", value="value")
+        _ = VariantMeta(namespace="provider", key="", value="value")
 
     for c in "@#$%&*^()[]?.!-{}[]\\/ ":
         with pytest.raises(ValueError, match="must match regex"):
-            _ = VariantMeta(provider="provider", key=f"access{c}key", value="value")
+            _ = VariantMeta(namespace="provider", key=f"access{c}key", value="value")
 
 
 def test_failing_regex_value():
     with pytest.raises(ValueError, match="must match regex"):
-        _ = VariantMeta(provider="provider", key="key", value="")
+        _ = VariantMeta(namespace="provider", key="key", value="")
 
     for c in "@#$%&*^()[]?!-{}[]\\/ ":
         with pytest.raises(ValueError, match="must match regex"):
-            _ = VariantMeta(provider="provider", key="key", value=f"val{c}ue")
+            _ = VariantMeta(namespace="provider", key="key", value=f"val{c}ue")
 
 
 @pytest.mark.parametrize(
@@ -104,7 +104,7 @@ def test_from_str_valid(input_str: str):
     variant_meta = VariantMeta.from_str(input_str)
 
     # Check if the resulting object matches the expected values
-    assert variant_meta.provider == "OmniCorp"
+    assert variant_meta.namespace == "OmniCorp"
     assert variant_meta.key == "access_key"
     assert variant_meta.value == "secret_value"
 
@@ -135,7 +135,7 @@ def test_from_str_trailing_spaces():
     variant_meta = VariantMeta.from_str(input_str.strip())
 
     # Check if it still correctly parses and matches the expected values
-    assert variant_meta.provider == "OmniCorp"
+    assert variant_meta.namespace == "OmniCorp"
     assert variant_meta.key == "access_key"
     assert variant_meta.value == "secret_value"
 
@@ -149,9 +149,9 @@ def test_from_str_invalid_format():
 
 
 def test_variantmeta_serialization():
-    vmeta = VariantMeta(provider="provider", key="key", value="value")
+    vmeta = VariantMeta(namespace="provider", key="key", value="value")
     assert vmeta.serialize() == {
-        "provider": "provider",
+        "namespace": "provider",
         "key": "key",
         "value": "value",
     }
@@ -159,14 +159,14 @@ def test_variantmeta_serialization():
 
 def test_variantmeta_deserialization():
     data = {
-        "provider": "provider",
+        "namespace": "provider",
         "key": "key",
         "value": "value",
     }
 
     vmeta = VariantMeta.deserialize(data)
 
-    assert vmeta.provider == data["provider"]
+    assert vmeta.namespace == data["namespace"]
     assert vmeta.key == data["key"]
     assert vmeta.value == data["value"]
 
@@ -178,9 +178,9 @@ def test_variantmeta_deserialization():
 
 def test_variantdescription_initialization():
     # Valid input: List of VariantMeta instances
-    meta1 = VariantMeta(provider="OmniCorp", key="access_key", value="secret_value")
+    meta1 = VariantMeta(namespace="OmniCorp", key="access_key", value="secret_value")
     meta2 = VariantMeta(
-        provider="TyrellCorporation", key="client_id", value="secret_key"
+        namespace="TyrellCorporation", key="client_id", value="secret_key"
     )
     variant_description = VariantDescription([meta1, meta2])
 
@@ -197,7 +197,7 @@ def test_variantdescription_invalid_data():
 
     # Test data containing non-VariantMeta instances
     invalid_meta = {
-        "provider": "OmniCorp",
+        "namespace": "OmniCorp",
         "key": "access_key",
         "value": "secret_value",
     }
@@ -207,40 +207,40 @@ def test_variantdescription_invalid_data():
 
 def test_variantdescription_duplicate_data():
     # Test that duplicate VariantMeta instances are removed
-    meta1 = VariantMeta(provider="OmniCorp", key="access_key", value="secret_value")
+    meta1 = VariantMeta(namespace="OmniCorp", key="access_key", value="secret_value")
     with pytest.raises(ValueError, match="Duplicate value"):
         _ = VariantDescription([meta1, meta1])
 
 
 def test_variantdescription_partial_duplicate_data():
     # Test that duplicate VariantMeta instances are removed
-    meta1 = VariantMeta(provider="OmniCorp", key="access_key", value="secret_value")
-    meta2 = VariantMeta(provider="OmniCorp", key="access_key", value="another_value")
+    meta1 = VariantMeta(namespace="OmniCorp", key="access_key", value="secret_value")
+    meta2 = VariantMeta(namespace="OmniCorp", key="access_key", value="another_value")
     with pytest.raises(ValueError, match="Duplicate value"):
         _ = VariantDescription([meta1, meta2])
 
 
 def test_variantdescription_sorted_data():
-    # Ensure that the data is sorted by provider, key, value
-    meta1 = VariantMeta(provider="OmniCorp", key="access_key", value="secret_value")
+    # Ensure that the data is sorted by namespace, key, value
+    meta1 = VariantMeta(namespace="OmniCorp", key="access_key", value="secret_value")
     meta2 = VariantMeta(
-        provider="TyrellCorporation", key="client_id", value="secret_key"
+        namespace="TyrellCorporation", key="client_id", value="secret_key"
     )
-    meta3 = VariantMeta(provider="OmniCorp", key="secret_key", value="client_value")
+    meta3 = VariantMeta(namespace="OmniCorp", key="secret_key", value="client_value")
     variant_description = VariantDescription([meta1, meta2, meta3])
 
-    # Check that data is sorted by provider, key, and value
+    # Check that data is sorted by namespace, key, and value
     sorted_data = sorted(
-        [meta1, meta2, meta3], key=lambda x: (x.provider, x.key, x.value)
+        [meta1, meta2, meta3], key=lambda x: (x.namespace, x.key, x.value)
     )
     assert list(variant_description) == sorted_data
 
 
 def test_variantdescription_hexdigest():
     # Ensure that the hexdigest property works correctly
-    meta1 = VariantMeta(provider="OmniCorp", key="access_key", value="secret_value")
+    meta1 = VariantMeta(namespace="OmniCorp", key="access_key", value="secret_value")
     meta2 = VariantMeta(
-        provider="TyrellCorporation", key="client_id", value="secret_key"
+        namespace="TyrellCorporation", key="client_id", value="secret_key"
     )
     variant_description = VariantDescription([meta1, meta2])
 
@@ -254,12 +254,12 @@ def test_variantdescription_hexdigest():
 
 
 def test_variantdescription_serialization():
-    vmeta = VariantMeta(provider="provider", key="key", value="value")
+    vmeta = VariantMeta(namespace="provider", key="key", value="value")
     vdesc = VariantDescription(data=[vmeta])
 
     assert vdesc.serialize() == [
         {
-            "provider": "provider",
+            "namespace": "provider",
             "key": "key",
             "value": "value",
         }
@@ -269,7 +269,7 @@ def test_variantdescription_serialization():
 def test_variantdescription_deserialization():
     data = [
         {
-            "provider": "provider",
+            "namespace": "provider",
             "key": "key",
             "value": "value",
         }
@@ -278,7 +278,7 @@ def test_variantdescription_deserialization():
     vdesc = VariantDescription.deserialize(data)
 
     assert len(vdesc.data) == 1
-    assert vdesc.data[0].provider == "provider"
+    assert vdesc.data[0].namespace == "provider"
     assert vdesc.data[0].key == "key"
     assert vdesc.data[0].value == "value"
     assert vdesc.hexdigest == "5b7306b3"
@@ -290,7 +290,7 @@ def test_variantdescription_deserialization():
 
 
 @pytest.mark.parametrize(
-    ("provider", "key", "value"),
+    ("namespace", "key", "value"),
     [
         ("OmniCorp", "access_key", "secret_value"),
         ("TyrellCorporation", "client_id", "secret_key"),
@@ -300,10 +300,10 @@ def test_variantdescription_deserialization():
         ("CyberdyneSystems", "version", "10.1.4"),
     ],
 )
-def test_fuzzy_variantmeta(provider, key, value):
+def test_fuzzy_variantmeta(namespace, key, value):
     # Fuzzy test for random combinations of VariantMeta
-    variant = VariantMeta(provider=provider, key=key, value=value)
-    assert variant.provider == provider
+    variant = VariantMeta(namespace=namespace, key=key, value=value)
+    assert variant.namespace == namespace
     assert variant.key == key
     assert variant.value == value
 
@@ -311,27 +311,27 @@ def test_fuzzy_variantmeta(provider, key, value):
 @pytest.mark.parametrize(
     "meta_data",
     [
-        ([VariantMeta(provider="OmniCorp", key="access_key", value="secret_value")]),
+        ([VariantMeta(namespace="OmniCorp", key="access_key", value="secret_value")]),
         (
             [
                 VariantMeta(
-                    provider="TyrellCorporation", key="client_id", value="secret_key"
+                    namespace="TyrellCorporation", key="client_id", value="secret_key"
                 ),
                 VariantMeta(
-                    provider="OmniCorp", key="access_key", value="secret_value"
+                    namespace="OmniCorp", key="access_key", value="secret_value"
                 ),
             ]
         ),
         (
             [
                 VariantMeta(
-                    provider="OmniCorp", key="access_key", value="secret_value"
+                    namespace="OmniCorp", key="access_key", value="secret_value"
                 ),
                 VariantMeta(
-                    provider="TyrellCorporation", key="client_id", value="secret_key"
+                    namespace="TyrellCorporation", key="client_id", value="secret_key"
                 ),
                 VariantMeta(
-                    provider="OmniCorp", key="secret_key", value="client_value"
+                    namespace="OmniCorp", key="secret_key", value="client_value"
                 ),
             ]
         ),
@@ -357,7 +357,7 @@ def test_random_hexdigest(num_entries):
 
     meta_data = [
         VariantMeta(
-            provider=random_string(5), key=random_string(5), value=random_string(8)
+            namespace=random_string(5), key=random_string(5), value=random_string(8)
         )
         for _ in range(num_entries)
     ]

--- a/tests/test_plugins.py
+++ b/tests/test_plugins.py
@@ -9,9 +9,11 @@ from variantlib.plugins import PluginLoader
 
 
 class MockedPluginA(PluginBase):
+    name = "test_plugin"
+
     def get_supported_configs(self) -> Optional[ProviderConfig]:
         return ProviderConfig(
-            provider="test_plugin",
+            provider=self.name,
             configs=[
                 KeyConfig("key1", ["val1a", "val1b"]),
                 KeyConfig("key2", ["val2a", "val2b", "val2c"]),
@@ -22,9 +24,11 @@ class MockedPluginA(PluginBase):
 # NB: this plugin deliberately does not inherit from PluginBase
 # to test that we don't rely on that inheritance
 class MockedPluginB:
+    name = "second_plugin"
+
     def get_supported_configs(self) -> Optional[ProviderConfig]:
         return ProviderConfig(
-            provider="second_plugin",
+            provider=self.name,
             configs=[
                 KeyConfig("key3", ["val3a"]),
             ],
@@ -32,6 +36,8 @@ class MockedPluginB:
 
 
 class MockedPluginC(PluginBase):
+    name = "incompatible_plugin"
+
     def get_supported_configs(self) -> Optional[ProviderConfig]:
         return None
 
@@ -64,9 +70,9 @@ def mocked_plugin_loader(session_mocker):
             plugin=MockedPluginA,
         ),
         MockedEntryPoint(
-            name="other_plugin",
+            name="second_plugin",
             value="tests.test_plugins:MockedPluginB",
-            dist=MockedDistribution(name="other-plugin", version="4.5.6"),
+            dist=MockedDistribution(name="second-plugin", version="4.5.6"),
             plugin=MockedPluginB,
         ),
         MockedEntryPoint(
@@ -81,7 +87,7 @@ def mocked_plugin_loader(session_mocker):
 
 def test_get_supported_configs(mocked_plugin_loader):
     assert mocked_plugin_loader.get_supported_configs() == {
-        "other_plugin": ProviderConfig(
+        "second_plugin": ProviderConfig(
             provider="second_plugin",
             configs=[
                 KeyConfig("key3", ["val3a"]),
@@ -100,6 +106,6 @@ def test_get_supported_configs(mocked_plugin_loader):
 def test_get_dist_name_mapping(mocked_plugin_loader):
     assert mocked_plugin_loader.get_dist_name_mapping() == {
         "incompatible_plugin": "incompatible-plugin",
-        "other_plugin": "other-plugin",
+        "second_plugin": "second-plugin",
         "test_plugin": "test-plugin",
     }

--- a/tests/test_plugins.py
+++ b/tests/test_plugins.py
@@ -78,7 +78,6 @@ def mocked_plugin_loader(session_mocker):
         MockedEntryPoint(
             name="incompatible_plugin",
             value="tests.test_plugins:MockedPluginC",
-            dist=MockedDistribution(name="incompatible-plugin", version="0.0.0"),
             plugin=MockedPluginC,
         ),
     ]
@@ -105,7 +104,6 @@ def test_get_supported_configs(mocked_plugin_loader):
 
 def test_get_dist_name_mapping(mocked_plugin_loader):
     assert mocked_plugin_loader.get_dist_name_mapping() == {
-        "incompatible_plugin": "incompatible-plugin",
         "second_plugin": "second-plugin",
         "test_plugin": "test-plugin",
     }

--- a/tests/test_plugins.py
+++ b/tests/test_plugins.py
@@ -9,11 +9,11 @@ from variantlib.plugins import PluginLoader
 
 
 class MockedPluginA(PluginBase):
-    name = "test_plugin"
+    namespace = "test_plugin"
 
     def get_supported_configs(self) -> Optional[ProviderConfig]:
         return ProviderConfig(
-            provider=self.name,
+            namespace=self.namespace,
             configs=[
                 KeyConfig("key1", ["val1a", "val1b"]),
                 KeyConfig("key2", ["val2a", "val2b", "val2c"]),
@@ -24,11 +24,11 @@ class MockedPluginA(PluginBase):
 # NB: this plugin deliberately does not inherit from PluginBase
 # to test that we don't rely on that inheritance
 class MockedPluginB:
-    name = "second_plugin"
+    namespace = "second_plugin"
 
     def get_supported_configs(self) -> Optional[ProviderConfig]:
         return ProviderConfig(
-            provider=self.name,
+            namespace=self.namespace,
             configs=[
                 KeyConfig("key3", ["val3a"]),
             ],
@@ -36,7 +36,7 @@ class MockedPluginB:
 
 
 class MockedPluginC(PluginBase):
-    name = "incompatible_plugin"
+    namespace = "incompatible_plugin"
 
     def get_supported_configs(self) -> Optional[ProviderConfig]:
         return None
@@ -87,13 +87,13 @@ def mocked_plugin_loader(session_mocker):
 def test_get_supported_configs(mocked_plugin_loader):
     assert mocked_plugin_loader.get_supported_configs() == {
         "second_plugin": ProviderConfig(
-            provider="second_plugin",
+            namespace="second_plugin",
             configs=[
                 KeyConfig("key3", ["val3a"]),
             ],
         ),
         "test_plugin": ProviderConfig(
-            provider="test_plugin",
+            namespace="test_plugin",
             configs=[
                 KeyConfig("key1", ["val1a", "val1b"]),
                 KeyConfig("key2", ["val2a", "val2b", "val2c"]),

--- a/variantlib/base.py
+++ b/variantlib/base.py
@@ -9,8 +9,8 @@ class PluginType(Protocol):
     """A protocol for plugin classes"""
 
     @property
-    def name(self) -> str:
-        """Get provider name"""
+    def namespace(self) -> str:
+        """Get provider namespace"""
         ...
 
     def get_supported_configs(self) -> ProviderConfig:
@@ -22,7 +22,7 @@ class PluginBase(ABC):
     """An abstract base class that can be used to implement plugins"""
 
     @abstractproperty
-    def name(self) -> str: ...
+    def namespace(self) -> str: ...
 
     @abstractmethod
     def get_supported_configs(self) -> ProviderConfig: ...

--- a/variantlib/base.py
+++ b/variantlib/base.py
@@ -1,4 +1,4 @@
-from abc import ABC, abstractmethod
+from abc import ABC, abstractmethod, abstractproperty
 from typing import Protocol, runtime_checkable
 
 from variantlib.config import ProviderConfig
@@ -8,6 +8,11 @@ from variantlib.config import ProviderConfig
 class PluginType(Protocol):
     """A protocol for plugin classes"""
 
+    @property
+    def name(self) -> str:
+        """Get provider name"""
+        ...
+
     def get_supported_configs(self) -> ProviderConfig:
         """Get supported configs for the current system"""
         ...
@@ -16,6 +21,8 @@ class PluginType(Protocol):
 class PluginBase(ABC):
     """An abstract base class that can be used to implement plugins"""
 
+    @abstractproperty
+    def name(self) -> str: ...
+
     @abstractmethod
-    def get_supported_configs(self) -> ProviderConfig:
-        ...
+    def get_supported_configs(self) -> ProviderConfig: ...

--- a/variantlib/config.py
+++ b/variantlib/config.py
@@ -59,7 +59,7 @@ class KeyConfig:
 
 @dataclass(frozen=True)
 class ProviderConfig:
-    provider: str = field(
+    namespace: str = field(
         metadata={
             "validators": [
                 lambda v: validate_instance_of(v, str),
@@ -101,7 +101,7 @@ class ProviderConfig:
             seen.add(key)
 
     def pretty_print(self) -> str:
-        result_str = f"{'#' * 20} Provider Config: `{self.provider}` {'#' * 20}"
+        result_str = f"{'#' * 20} Provider Config: `{self.namespace}` {'#' * 20}"
         for kid, vconfig in enumerate(self.configs):
             result_str += (
                 f"\n\t- Variant Config [{kid + 1:03d}]: "

--- a/variantlib/platform.py
+++ b/variantlib/platform.py
@@ -39,19 +39,19 @@ def _query_variant_plugins() -> dict[str, ProviderConfig]:
 def get_variant_hashes_by_priority(
     *,
     variants_json: dict,
-    provider_priority_dict: Optional[dict[str:int]] = None,
+    namespace_priority_dict: Optional[dict[str:int]] = None,
 ) -> Generator[VariantDescription]:
     provider_cfgs = _query_variant_plugins()
 
     # sorting providers in priority order:
-    if provider_priority_dict is not None:
+    if namespace_priority_dict is not None:
         if (
-            not isinstance(provider_priority_dict, dict)
-            or not all(isinstance(key, str) for key in provider_priority_dict)
-            or not all(isinstance(key, int) for key in provider_priority_dict.values())
+            not isinstance(namespace_priority_dict, dict)
+            or not all(isinstance(key, str) for key in namespace_priority_dict)
+            or not all(isinstance(key, int) for key in namespace_priority_dict.values())
         ):
             logger.warning(
-                "Invalid `provider_priority_dict` provided. Should follow "
+                "Invalid `namespace_priority_dict` provided. Should follow "
                 "format: dict[str:int]. Ignoring..."
             )
         else:
@@ -59,7 +59,7 @@ def get_variant_hashes_by_priority(
             value_to_keys = defaultdict(list)  # temp storage
 
             # Populate the dictionary with values and their corresponding keys
-            for key, value in provider_priority_dict.items():
+            for key, value in namespace_priority_dict.items():
                 value_to_keys[value].append(key)
 
             # Isolate the duplicate values and their corresponding keys
@@ -73,25 +73,25 @@ def get_variant_hashes_by_priority(
                     logger.warning("Value: %s -> Keys: %s", value, keys)
 
             # ----------- Checking if two plugins hold the same priority ----------- #
-            for plugin_name in provider_cfgs:
-                if plugin_name not in provider_priority_dict:
+            for namespace in provider_cfgs:
+                if namespace not in namespace_priority_dict:
                     logger.warning(
-                        "Plugin: %s is not present in the `provider_priority_dict`. "
+                        "Plugin: %s is not present in the `namespace_priority_dict`. "
                         "Will be treated as lowest priority.",
-                        plugin_name,
+                        namespace,
                     )
                     continue
 
             # ------------------- Sorting the plugins by priority ------------------ #
             plugins = sorted(
                 provider_cfgs,
-                key=lambda plugin_name: provider_priority_dict.get(
-                    plugin_name, float("inf")
+                key=lambda namespace: namespace_priority_dict.get(
+                    namespace, float("inf")
                 ),
             )
 
             sorted_provider_cfgs = [
-                provider_cfgs[plugin_name] for plugin_name in plugins
+                provider_cfgs[namespace] for namespace in plugins
             ]
     else:
         sorted_provider_cfgs = list(provider_cfgs.values())

--- a/variantlib/plugins.py
+++ b/variantlib/plugins.py
@@ -27,7 +27,17 @@ class PluginLoader(metaclass=SingletonMetaClass):
 
         for plugin in plugins:
             try:
-                logger.info(f"Loading plugin: {plugin.name} - v{plugin.dist.version}")  # noqa: G004
+                logger.info(
+                    "Loading plugin: %(name)s - version %(version)s",
+                    {
+                        "name": plugin.name,
+                        "version": (
+                            plugin.dist.version
+                            if plugin.dist is not None
+                            else "unknown"
+                        ),
+                    },
+                )
 
                 # Dynamically load the plugin class
                 plugin_class = plugin.load()
@@ -42,7 +52,8 @@ class PluginLoader(metaclass=SingletonMetaClass):
                     duplicates.add(plugin_instance.name)
                 self._plugins[plugin_instance.name] = plugin_instance
 
-                self._dist_names[plugin_instance.name] = plugin.dist.name
+                if plugin.dist is not None:
+                    self._dist_names[plugin_instance.name] = plugin.dist.name
 
         if duplicates:
             logger.warning(

--- a/variantlib/plugins.py
+++ b/variantlib/plugins.py
@@ -49,16 +49,18 @@ class PluginLoader(metaclass=SingletonMetaClass):
                 logging.exception("An unknown error happened - Ignoring plugin")
             else:
                 if plugin_instance.namespace in self._plugins:
-                    duplicates.add(plugin_instance.namespace)
+                    pkg1 = self._dist_names.get(plugin_instance.namespace)
+                    pkg2 = plugin.dist.name if plugin.dist is not None else None
+                    if pkg1 is not None and pkg2 is not None:
+                        hint = f": {pkg1} or {pkg2}."
+                    raise RuntimeError(
+                        "Two plugins found using the same namespace "
+                        f"{plugin_instance.namespace}. Refusing to proceed. "
+                        f"Please uninstall one of them{hint}..")
                 self._plugins[plugin_instance.namespace] = plugin_instance
 
                 if plugin.dist is not None:
                     self._dist_names[plugin_instance.namespace] = plugin.dist.name
-
-        if duplicates:
-            logger.warning(
-                "Duplicate plugins found: %s - Unpredicatable behavior.", duplicates
-            )
 
     def get_supported_configs(self) -> dict[str, ProviderConfig]:
         """Get a mapping of plugin names to provider configs"""

--- a/variantlib/plugins.py
+++ b/variantlib/plugins.py
@@ -48,11 +48,12 @@ class PluginLoader(metaclass=SingletonMetaClass):
                 plugin_class = plugin.load()
 
                 # Instantiate the plugin
-                self._plugins[plugin.name] = plugin_class()
-                assert isinstance(self._plugins[plugin.name], PluginType)
+                plugin_instance = plugin_class()
+                assert isinstance(plugin_instance, PluginType)
+                self._plugins[plugin_instance.name] = plugin_instance
 
                 # Store package distribution names for later use
-                self._dist_names[plugin.name] = plugin.dist.name
+                self._dist_names[plugin_instance.name] = plugin.dist.name
             except Exception:
                 logging.exception("An unknown error happened - Ignoring plugin")
 
@@ -67,6 +68,14 @@ class PluginLoader(metaclass=SingletonMetaClass):
                 logging.error(
                     f"Provider: {name} returned an unexpected type: "  # noqa: G004
                     f"{type(provider_cfg)} - Expected: `ProviderConfig`. Ignoring..."
+                )
+                continue
+
+            if provider_cfg.provider != name:
+                logging.error(
+                    "Provider %(name)s returned different provider name "
+                    "in config: %(cfg_name)s. Ignoring...",
+                    {"name": name, "cfg_name": provider_cfg.provider},
                 )
                 continue
 

--- a/variantlib/plugins.py
+++ b/variantlib/plugins.py
@@ -48,12 +48,12 @@ class PluginLoader(metaclass=SingletonMetaClass):
             except Exception:
                 logging.exception("An unknown error happened - Ignoring plugin")
             else:
-                if plugin_instance.name in self._plugins:
-                    duplicates.add(plugin_instance.name)
-                self._plugins[plugin_instance.name] = plugin_instance
+                if plugin_instance.namespace in self._plugins:
+                    duplicates.add(plugin_instance.namespace)
+                self._plugins[plugin_instance.namespace] = plugin_instance
 
                 if plugin.dist is not None:
-                    self._dist_names[plugin_instance.name] = plugin.dist.name
+                    self._dist_names[plugin_instance.namespace] = plugin.dist.name
 
         if duplicates:
             logger.warning(
@@ -64,25 +64,25 @@ class PluginLoader(metaclass=SingletonMetaClass):
         """Get a mapping of plugin names to provider configs"""
 
         provider_cfgs = {}
-        for name, plugin_instance in self._plugins.items():
+        for namespace, plugin_instance in self._plugins.items():
             provider_cfg = plugin_instance.get_supported_configs()
 
             if not isinstance(provider_cfg, ProviderConfig):
                 logging.error(
-                    f"Provider: {name} returned an unexpected type: "  # noqa: G004
+                    f"Provider: {namespace} returned an unexpected type: "  # noqa: G004
                     f"{type(provider_cfg)} - Expected: `ProviderConfig`. Ignoring..."
                 )
                 continue
 
-            if provider_cfg.provider != name:
+            if provider_cfg.namespace != namespace:
                 logging.error(
-                    "Provider %(name)s returned different provider name "
+                    "Provider %(namespace)s returned different provider namespace "
                     "in config: %(cfg_name)s. Ignoring...",
-                    {"name": name, "cfg_name": provider_cfg.provider},
+                    {"namespace": namespace, "cfg_name": provider_cfg.provider},
                 )
                 continue
 
-            provider_cfgs[name] = provider_cfg
+            provider_cfgs[namespace] = provider_cfg
 
         return provider_cfgs
 


### PR DESCRIPTION
Add a public `name` property and use it to identify plugins over the current mix of entry point and `ProviderConfig` names. We require that `ProviderConfig` specifies the same name now. Related to https://github.com/wheelnext/pep_xxx_wheel_variants/issues/16.

I've also made the distribution name/version entirely optional, as entry points API apparently permits entry points without a distribution.

Do you want me to add a `version` field as well?

Also, I'm wondering if we shouldn't put our demo plugins in a single repository. Updating them for API changes separately is a bit of a hassle now.