### PR TITLE
Support using custom implementation of key configs in API

### DIFF
--- a/tests/test_plugins.py
+++ b/tests/test_plugins.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+from collections import namedtuple
 from dataclasses import dataclass
 from typing import Any
 
@@ -20,14 +21,17 @@ class MockedPluginA(PluginBase):
         ]
 
 
+MyKeyConfig = namedtuple("MyKeyConfig", ("key", "values"))
+
+
 # NB: this plugin deliberately does not inherit from PluginBase
 # to test that we don't rely on that inheritance
 class MockedPluginB:
     namespace = "second_plugin"
 
-    def get_supported_configs(self) -> list[KeyConfig]:
+    def get_supported_configs(self) -> list[MyKeyConfig]:
         return [
-            KeyConfig("key3", ["val3a"]),
+            MyKeyConfig("key3", ["val3a"]),
         ]
 
 

--- a/tests/test_plugins.py
+++ b/tests/test_plugins.py
@@ -5,6 +5,7 @@ from dataclasses import dataclass
 from typing import Any
 
 import pytest
+from variantlib.base import KeyConfigType
 from variantlib.base import PluginBase
 from variantlib.config import KeyConfig
 from variantlib.config import ProviderConfig
@@ -14,7 +15,7 @@ from variantlib.loader import PluginLoader
 class MockedPluginA(PluginBase):
     namespace = "test_plugin"
 
-    def get_supported_configs(self) -> list[KeyConfig]:
+    def get_supported_configs(self) -> list[KeyConfigType]:
         return [
             KeyConfig("key1", ["val1a", "val1b"]),
             KeyConfig("key2", ["val2a", "val2b", "val2c"]),
@@ -38,14 +39,14 @@ class MockedPluginB:
 class MockedPluginC(PluginBase):
     namespace = "incompatible_plugin"
 
-    def get_supported_configs(self) -> list[KeyConfig]:
+    def get_supported_configs(self) -> list[KeyConfigType]:
         return []
 
 
 class ClashingPlugin(PluginBase):
     namespace = "test_plugin"
 
-    def get_supported_configs(self) -> list[KeyConfig]:
+    def get_supported_configs(self) -> list[KeyConfigType]:
         return []
 
 

--- a/tests/test_plugins.py
+++ b/tests/test_plugins.py
@@ -6,13 +6,13 @@ from typing import Any
 
 import pytest
 from variantlib.base import KeyConfigType
-from variantlib.base import PluginBase
+from variantlib.base import PluginType
 from variantlib.config import KeyConfig
 from variantlib.config import ProviderConfig
 from variantlib.loader import PluginLoader
 
 
-class MockedPluginA(PluginBase):
+class MockedPluginA(PluginType):
     namespace = "test_plugin"
 
     def get_supported_configs(self) -> list[KeyConfigType]:
@@ -25,7 +25,7 @@ class MockedPluginA(PluginBase):
 MyKeyConfig = namedtuple("MyKeyConfig", ("key", "values"))
 
 
-# NB: this plugin deliberately does not inherit from PluginBase
+# NB: this plugin deliberately does not inherit from PluginType
 # to test that we don't rely on that inheritance
 class MockedPluginB:
     namespace = "second_plugin"
@@ -36,14 +36,14 @@ class MockedPluginB:
         ]
 
 
-class MockedPluginC(PluginBase):
+class MockedPluginC(PluginType):
     namespace = "incompatible_plugin"
 
     def get_supported_configs(self) -> list[KeyConfigType]:
         return []
 
 
-class ClashingPlugin(PluginBase):
+class ClashingPlugin(PluginType):
     namespace = "test_plugin"
 
     def get_supported_configs(self) -> list[KeyConfigType]:

--- a/tests/test_plugins.py
+++ b/tests/test_plugins.py
@@ -13,14 +13,11 @@ from variantlib.loader import PluginLoader
 class MockedPluginA(PluginBase):
     namespace = "test_plugin"
 
-    def get_supported_configs(self) -> ProviderConfig | None:
-        return ProviderConfig(
-            namespace=self.namespace,
-            configs=[
-                KeyConfig("key1", ["val1a", "val1b"]),
-                KeyConfig("key2", ["val2a", "val2b", "val2c"]),
-            ],
-        )
+    def get_supported_configs(self) -> list[KeyConfig]:
+        return [
+            KeyConfig("key1", ["val1a", "val1b"]),
+            KeyConfig("key2", ["val2a", "val2b", "val2c"]),
+        ]
 
 
 # NB: this plugin deliberately does not inherit from PluginBase
@@ -28,27 +25,24 @@ class MockedPluginA(PluginBase):
 class MockedPluginB:
     namespace = "second_plugin"
 
-    def get_supported_configs(self) -> ProviderConfig | None:
-        return ProviderConfig(
-            namespace=self.namespace,
-            configs=[
-                KeyConfig("key3", ["val3a"]),
-            ],
-        )
+    def get_supported_configs(self) -> list[KeyConfig]:
+        return [
+            KeyConfig("key3", ["val3a"]),
+        ]
 
 
 class MockedPluginC(PluginBase):
     namespace = "incompatible_plugin"
 
-    def get_supported_configs(self) -> ProviderConfig | None:
-        return None
+    def get_supported_configs(self) -> list[KeyConfig]:
+        return []
 
 
 class ClashingPlugin(PluginBase):
     namespace = "test_plugin"
 
-    def get_supported_configs(self) -> ProviderConfig | None:
-        return None
+    def get_supported_configs(self) -> list[KeyConfig]:
+        return []
 
 
 @dataclass

--- a/variantlib/base.py
+++ b/variantlib/base.py
@@ -2,10 +2,12 @@ from __future__ import annotations
 
 from abc import ABC
 from abc import abstractmethod
+from typing import TYPE_CHECKING
 from typing import Protocol
 from typing import runtime_checkable
 
-from variantlib.config import ProviderConfig
+if TYPE_CHECKING:
+    from variantlib.config import KeyConfig
 
 
 @runtime_checkable
@@ -17,7 +19,7 @@ class PluginType(Protocol):
         """Get provider namespace"""
         ...
 
-    def get_supported_configs(self) -> ProviderConfig:
+    def get_supported_configs(self) -> list[KeyConfig]:
         """Get supported configs for the current system"""
         ...
 
@@ -30,4 +32,4 @@ class PluginBase(ABC):
     def namespace(self) -> str: ...
 
     @abstractmethod
-    def get_supported_configs(self) -> ProviderConfig: ...
+    def get_supported_configs(self) -> list[KeyConfig]: ...

--- a/variantlib/base.py
+++ b/variantlib/base.py
@@ -10,8 +10,15 @@ from typing import runtime_checkable
 class KeyConfigType(Protocol):
     """A protocol for key configs"""
 
-    key: str
-    values: list[str]
+    @property
+    def key(self) -> str:
+        """Key name"""
+        ...
+
+    @property
+    def values(self) -> list[str]:
+        """Ordered list of values, most preferred first"""
+        ...
 
 
 @runtime_checkable

--- a/variantlib/base.py
+++ b/variantlib/base.py
@@ -1,6 +1,5 @@
 from __future__ import annotations
 
-from abc import ABC
 from abc import abstractmethod
 from typing import Protocol
 from typing import runtime_checkable
@@ -26,21 +25,12 @@ class PluginType(Protocol):
     """A protocol for plugin classes"""
 
     @property
+    @abstractmethod
     def namespace(self) -> str:
         """Get provider namespace"""
-        ...
+        raise NotImplementedError
 
+    @abstractmethod
     def get_supported_configs(self) -> list[KeyConfigType]:
         """Get supported configs for the current system"""
-        ...
-
-
-class PluginBase(ABC):
-    """An abstract base class that can be used to implement plugins"""
-
-    @property
-    @abstractmethod
-    def namespace(self) -> str: ...
-
-    @abstractmethod
-    def get_supported_configs(self) -> list[KeyConfigType]: ...
+        raise NotImplementedError

--- a/variantlib/base.py
+++ b/variantlib/base.py
@@ -2,12 +2,16 @@ from __future__ import annotations
 
 from abc import ABC
 from abc import abstractmethod
-from typing import TYPE_CHECKING
 from typing import Protocol
 from typing import runtime_checkable
 
-if TYPE_CHECKING:
-    from variantlib.config import KeyConfig
+
+@runtime_checkable
+class KeyConfigType(Protocol):
+    """A protocol for key configs"""
+
+    key: str
+    values: list[str]
 
 
 @runtime_checkable
@@ -19,7 +23,7 @@ class PluginType(Protocol):
         """Get provider namespace"""
         ...
 
-    def get_supported_configs(self) -> list[KeyConfig]:
+    def get_supported_configs(self) -> list[KeyConfigType]:
         """Get supported configs for the current system"""
         ...
 
@@ -32,4 +36,4 @@ class PluginBase(ABC):
     def namespace(self) -> str: ...
 
     @abstractmethod
-    def get_supported_configs(self) -> list[KeyConfig]: ...
+    def get_supported_configs(self) -> list[KeyConfigType]: ...

--- a/variantlib/loader.py
+++ b/variantlib/loader.py
@@ -20,8 +20,8 @@ class classproperty(property):  # noqa: N801
 class PluginLoader:
     """Load and query plugins"""
 
-    _plugins = {}
-    _dist_names = {}
+    _plugins: dict[str, PluginType] = {}
+    _dist_names: dict[str, str] = {}
 
     def __new__(cls, *args, **kwargs):
         raise RuntimeError(f"Cannot instantiate {cls.__name__}")
@@ -123,7 +123,7 @@ class PluginLoader:
         return cls._dist_names
 
     @classproperty
-    def plugins(cls) -> dict[str, str]:  # noqa: N805
+    def plugins(cls) -> dict[str, PluginType]:  # noqa: N805
         """Get the loaded plugins"""
         return cls._plugins
 

--- a/variantlib/loader.py
+++ b/variantlib/loader.py
@@ -5,6 +5,7 @@ from importlib.metadata import entry_points
 
 from variantlib.base import PluginType
 from variantlib.cache import VariantCache
+from variantlib.config import KeyConfig
 from variantlib.config import ProviderConfig
 
 logger = logging.getLogger(__name__)
@@ -57,7 +58,7 @@ class PluginLoader:
                 # Instantiate the plugin
                 plugin_instance = plugin_class()
                 assert isinstance(plugin_instance, PluginType)
-            except Exception:  # noqa: PERF203
+            except Exception:
                 logging.exception("An unknown error happened - Ignoring plugin")
             else:
                 if plugin_instance.namespace in cls._plugins:
@@ -82,24 +83,32 @@ class PluginLoader:
 
         provider_cfgs = {}
         for namespace, plugin_instance in cls._plugins.items():
-            provider_cfg = plugin_instance.get_supported_configs()
+            key_configs = plugin_instance.get_supported_configs()
 
-            if not isinstance(provider_cfg, ProviderConfig):
+            if not isinstance(key_configs, list):
                 logging.error(
-                    f"Provider: {namespace} returned an unexpected type: "  # noqa: G004
-                    f"{type(provider_cfg)} - Expected: `ProviderConfig`. Ignoring..."
+                    "Provider: %(namespace)s returned an unexpected type: "
+                    "%(type)s - Expected: `list[KeyConfig]`. Ignoring...",
+                    {"namespace": namespace, "type": type(key_configs)},
                 )
                 continue
 
-            if provider_cfg.namespace != namespace:
-                logging.error(
-                    "Provider %(namespace)s returned different provider namespace "
-                    "in config: %(cfg_name)s. Ignoring...",
-                    {"namespace": namespace, "cfg_name": provider_cfg.provider},
-                )
+            # skip providers that do not return any supported configs
+            if not key_configs:
                 continue
 
-            provider_cfgs[namespace] = provider_cfg
+            for key_cfg in key_configs:
+                if not isinstance(key_cfg, KeyConfig):
+                    logging.error(
+                        "Provider: %(namespace)s returned an unexpected list member "
+                        "type: %(type)s - Expected: `KeyConfig`. Ignoring...",
+                        {"namespace": namespace, "type": type(key_configs)},
+                    )
+                    continue
+
+            provider_cfgs[namespace] = ProviderConfig(
+                plugin_instance.namespace, configs=key_configs
+            )
 
         return provider_cfgs
 

--- a/variantlib/loader.py
+++ b/variantlib/loader.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import logging
 from importlib.metadata import entry_points
 
+from variantlib.base import KeyConfigType
 from variantlib.base import PluginType
 from variantlib.cache import VariantCache
 from variantlib.config import KeyConfig
@@ -98,16 +99,20 @@ class PluginLoader:
                 continue
 
             for key_cfg in key_configs:
-                if not isinstance(key_cfg, KeyConfig):
+                if not isinstance(key_cfg, KeyConfigType):
                     logging.error(
                         "Provider: %(namespace)s returned an unexpected list member "
-                        "type: %(type)s - Expected: `KeyConfig`. Ignoring...",
+                        "type: %(type)s - Expected: `KeyConfigType`. Ignoring...",
                         {"namespace": namespace, "type": type(key_configs)},
                     )
                     continue
 
             provider_cfgs[namespace] = ProviderConfig(
-                plugin_instance.namespace, configs=key_configs
+                plugin_instance.namespace,
+                configs=[
+                    KeyConfig(key=key_cfg.key, values=key_cfg.values)
+                    for key_cfg in key_configs
+                ],
             )
 
         return provider_cfgs


### PR DESCRIPTION
Add support for plugins implementing their own key config type rather than using the one from `variantlib`.  To account for that, introduce a `KeyConfigType` protocol that verifies that all mandatory fields are present, and convert the data passed by plugins to `KeyConfig` in plugin loader.

This is a step towards detaching the specification from `variantlib` internals.  Allowing an arbitrary implementation should improve compatibility with non-Python implementations, and also avoid potential issues when plugins use a different version of `variantlib` than the one vendored in `pip`.

See also: https://github.com/wheelnext/pep_xxx_wheel_variants/issues/11