### PR TITLE
Add complete error handling to `PluginLoader`, and cover almost all of it with tests

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -28,7 +28,10 @@ maintainers = [
     { name = "Jonathan Dekhtiar", email = "jonathan@dekhtiar.com" },
     { name = "Michael Sarahan", email = "msarahan@nvidia.com" },
 ]
-dependencies = ["typing-extensions; python_version < '3.11'"]
+dependencies = [
+    "importlib-metadata; python_version < '3.10'",
+    "typing-extensions; python_version < '3.11'",
+]
 
 [project.optional-dependencies]
 dev = [

--- a/tests/test_plugins.py
+++ b/tests/test_plugins.py
@@ -274,9 +274,9 @@ def test_get_configs_incorrect_list_member_type(method: str, mocker):
         match=re.escape(
             f"Provider exception_test, {method}() method returned incorrect type. "
             "Expected list[variantlib.base.VariantFeatureConfigType], "
-            "got list[variantlib.base.VariantFeatureConfigType | "
+            "got list[typing.Union[variantlib.base.VariantFeatureConfigType, "
         )
-        + r"(dict \| int|int \| dict)",
+        + r"(dict, int|int, dict)",
     ):
         getattr(PluginLoader, method)()
 

--- a/tests/test_plugins.py
+++ b/tests/test_plugins.py
@@ -1,9 +1,9 @@
 from __future__ import annotations
 
 import re
+import sys
 from collections import namedtuple
 from dataclasses import dataclass
-from importlib.metadata import EntryPoint
 from typing import Any
 
 import pytest
@@ -14,6 +14,11 @@ from variantlib.errors import PluginError
 from variantlib.loader import PluginLoader
 from variantlib.models.provider import ProviderConfig
 from variantlib.models.provider import VariantFeatureConfig
+
+if sys.version_info >= (3, 10):
+    from importlib.metadata import EntryPoint
+else:
+    from importlib_metadata import EntryPoint
 
 
 class MockedPluginA(PluginType):

--- a/tests/test_plugins.py
+++ b/tests/test_plugins.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import re
 from collections import namedtuple
 from dataclasses import dataclass
 from typing import Any
@@ -219,7 +220,8 @@ def test_namespace_clash(mocker):
         PluginLoader.load_plugins()
 
 
-def test_get_all_configs_incorrect_list_type(mocker):
+@pytest.mark.parametrize("method", ["get_all_configs", "get_supported_configs"])
+def test_get_configs_incorrect_list_type(method: str, mocker):
     mocker.patch("variantlib.loader.entry_points")().select.return_value = [
         MockedEntryPoint(
             name="exception_test",
@@ -231,11 +233,13 @@ def test_get_all_configs_incorrect_list_type(mocker):
     ]
     with pytest.raises(
         TypeError,
-        match=r"Provider exception_test, get_all_configs\(\) method returned "
-        r"incorrect type. Expected list\[variantlib.base.VariantFeatureConfigType\], "
-        r"got <class 'tuple'>",
+        match=re.escape(
+            f"Provider exception_test, {method}() method returned incorrect type. "
+            "Expected list[variantlib.base.VariantFeatureConfigType], "
+            "got <class 'tuple'>"
+        ),
     ):
-        PluginLoader.get_all_configs()
+        getattr(PluginLoader, method)()
 
 
 def test_get_all_configs_incorrect_list_length(mocker):
@@ -254,7 +258,8 @@ def test_get_all_configs_incorrect_list_length(mocker):
         PluginLoader.get_all_configs()
 
 
-def test_get_all_configs_incorrect_list_member_type(mocker):
+@pytest.mark.parametrize("method", ["get_all_configs", "get_supported_configs"])
+def test_get_configs_incorrect_list_member_type(method: str, mocker):
     mocker.patch("variantlib.loader.entry_points")().select.return_value = [
         MockedEntryPoint(
             name="exception_test",
@@ -266,9 +271,11 @@ def test_get_all_configs_incorrect_list_member_type(mocker):
     ]
     with pytest.raises(
         TypeError,
-        match=r"Provider exception_test, get_all_configs\(\) method returned "
-        r"incorrect type. Expected list\[variantlib.base.VariantFeatureConfigType\], "
-        r"got list\[variantlib.base.VariantFeatureConfigType \| str \| tuple \| bool "
-        r"\| dict \| int\]",
+        match=re.escape(
+            f"Provider exception_test, {method}() method returned incorrect type. "
+            "Expected list[variantlib.base.VariantFeatureConfigType], "
+            "got list[variantlib.base.VariantFeatureConfigType | str | tuple | bool "
+            "| dict | int]"
+        ),
     ):
-        PluginLoader.get_all_configs()
+        getattr(PluginLoader, method)()

--- a/tests/test_plugins.py
+++ b/tests/test_plugins.py
@@ -266,9 +266,7 @@ def test_get_configs_incorrect_list_member_type(method: str, mocker):
         MockedEntryPoint(
             name="exception_test",
             value="tests.test_plugins:ExceptionTestingPlugin",
-            plugin=ExceptionTestingPlugin(
-                [{"k1": ["v1"], "k2": ["v2"]}, "k3", 1, True, (1, 2, 3)]
-            ),
+            plugin=ExceptionTestingPlugin([{"k1": ["v1"], "k2": ["v2"]}, 1]),
         ),
     ]
     with pytest.raises(
@@ -276,9 +274,9 @@ def test_get_configs_incorrect_list_member_type(method: str, mocker):
         match=re.escape(
             f"Provider exception_test, {method}() method returned incorrect type. "
             "Expected list[variantlib.base.VariantFeatureConfigType], "
-            "got list[variantlib.base.VariantFeatureConfigType | str | tuple | bool "
-            "| dict | int]"
-        ),
+            "got list[variantlib.base.VariantFeatureConfigType | "
+        )
+        + r"(dict \| int|int \| dict)",
     ):
         getattr(PluginLoader, method)()
 

--- a/tests/test_plugins.py
+++ b/tests/test_plugins.py
@@ -231,8 +231,9 @@ def test_get_all_configs_incorrect_list_type(mocker):
     ]
     with pytest.raises(
         TypeError,
-        match=r"Provider exception_test, get_all_configs\(\) method returned incorrect "
-        r"type <class 'tuple'>, excepted: list\[VariantFeatureConfig\]",
+        match=r"Provider exception_test, get_all_configs\(\) method returned "
+        r"incorrect type. Expected list\[variantlib.base.VariantFeatureConfigType\], "
+        r"got <class 'tuple'>",
     ):
         PluginLoader.get_all_configs()
 
@@ -258,12 +259,16 @@ def test_get_all_configs_incorrect_list_member_type(mocker):
         MockedEntryPoint(
             name="exception_test",
             value="tests.test_plugins:ExceptionTestingPlugin",
-            plugin=ExceptionTestingPlugin([{"k1": ["v1"], "k2": ["v2"]}]),
+            plugin=ExceptionTestingPlugin(
+                [{"k1": ["v1"], "k2": ["v2"]}, "k3", 1, True, (1, 2, 3)]
+            ),
         ),
     ]
     with pytest.raises(
         TypeError,
-        match=r"Provider exception_test, get_all_configs\(\) method returned incorrect "
-        r"list member type <class 'dict'>, excepted: VariantFeatureConfig",
+        match=r"Provider exception_test, get_all_configs\(\) method returned "
+        r"incorrect type. Expected list\[variantlib.base.VariantFeatureConfigType\], "
+        r"got list\[variantlib.base.VariantFeatureConfigType \| str \| tuple \| bool "
+        r"\| dict \| int\]",
     ):
         PluginLoader.get_all_configs()

--- a/variantlib/commands/main.py
+++ b/variantlib/commands/main.py
@@ -3,9 +3,14 @@
 from __future__ import annotations
 
 import argparse
-from importlib.metadata import entry_points
+import sys
 
 import variantlib
+
+if sys.version_info >= (3, 10):
+    from importlib.metadata import entry_points
+else:
+    from importlib_metadata import entry_points
 
 
 def main() -> None:

--- a/variantlib/errors.py
+++ b/variantlib/errors.py
@@ -1,2 +1,6 @@
 class ValidationError(ValueError):
     pass
+
+
+class PluginError(RuntimeError):
+    pass

--- a/variantlib/loader.py
+++ b/variantlib/loader.py
@@ -2,7 +2,6 @@ from __future__ import annotations
 
 import logging
 import sys
-from importlib.metadata import entry_points
 from types import MethodType
 from typing import TYPE_CHECKING
 from typing import Any
@@ -15,6 +14,11 @@ from variantlib.models.provider import VariantFeatureConfig
 from variantlib.models.validators import ValidationError
 from variantlib.models.validators import validate_type
 from variantlib.utils import classproperty
+
+if sys.version_info >= (3, 10):
+    from importlib.metadata import entry_points
+else:
+    from importlib_metadata import entry_points
 
 if sys.version_info >= (3, 11):
     from typing import Self

--- a/variantlib/loader.py
+++ b/variantlib/loader.py
@@ -162,9 +162,9 @@ class PluginLoader:
         cls.load_plugins()
         provider_cfgs = {}
         for namespace, plugin_instance in cls._plugins.items():
-            key_configs = cls._call(plugin_instance.get_all_configs)
+            vfeat_configs = cls._call(plugin_instance.get_all_configs)
 
-            if not key_configs:
+            if not vfeat_configs:
                 raise ValueError(
                     f"Provider {namespace}, get_all_configs() method returned no valid "
                     "configs"
@@ -174,7 +174,7 @@ class PluginLoader:
                 plugin_instance.namespace,
                 configs=[
                     VariantFeatureConfig(name=vfeat_cfg.name, values=vfeat_cfg.values)
-                    for vfeat_cfg in key_configs
+                    for vfeat_cfg in vfeat_configs
                 ],
             )
 

--- a/variantlib/loader.py
+++ b/variantlib/loader.py
@@ -54,12 +54,14 @@ class PluginLoader:
 
         for plugin in plugins:
             logger.info(
-                "Loading plugin: %(name)s - version %(version)s",
+                "Loading plugin from entry point: %(name)s; provided by package "
+                "%(package)s %(version)s",
                 {
                     "name": plugin.name,
-                    "version": (
-                        plugin.dist.version if plugin.dist is not None else "unknown"
-                    ),
+                    "package": plugin.dist.name
+                    if plugin.dist is not None
+                    else "unknown",
+                    "version": (plugin.dist.version if plugin.dist is not None else ""),
                 },
             )
 

--- a/variantlib/models/provider.py
+++ b/variantlib/models/provider.py
@@ -9,12 +9,11 @@ from variantlib.constants import VALIDATION_NAMESPACE_REGEX
 from variantlib.constants import VALIDATION_VALUE_REGEX
 from variantlib.models.base import BaseModel
 from variantlib.models.validators import validate_and
-from variantlib.models.validators import validate_instance_of
 from variantlib.models.validators import validate_list_all_unique
 from variantlib.models.validators import validate_list_matches_re
 from variantlib.models.validators import validate_list_min_len
-from variantlib.models.validators import validate_list_of
 from variantlib.models.validators import validate_matches_re
+from variantlib.models.validators import validate_type
 
 
 @dataclass(frozen=True)
@@ -23,7 +22,7 @@ class VariantFeatureConfig(BaseModel):
         metadata={
             "validator": lambda val: validate_and(
                 [
-                    lambda v: validate_instance_of(v, str),
+                    lambda v: validate_type(v, str),
                     lambda v: validate_matches_re(v, VALIDATION_FEATURE_REGEX),
                 ],
                 value=val,
@@ -36,8 +35,7 @@ class VariantFeatureConfig(BaseModel):
         metadata={
             "validator": lambda val: validate_and(
                 [
-                    lambda v: validate_instance_of(v, list),
-                    lambda v: validate_list_of(v, str),
+                    lambda v: validate_type(v, list[str]),
                     lambda v: validate_list_matches_re(v, VALIDATION_VALUE_REGEX),
                     lambda v: validate_list_min_len(v, 1),
                     lambda v: validate_list_all_unique(v),
@@ -54,7 +52,7 @@ class ProviderConfig(BaseModel):
         metadata={
             "validator": lambda val: validate_and(
                 [
-                    lambda v: validate_instance_of(v, str),
+                    lambda v: validate_type(v, str),
                     lambda v: validate_matches_re(v, VALIDATION_NAMESPACE_REGEX),
                 ],
                 value=val,
@@ -67,8 +65,7 @@ class ProviderConfig(BaseModel):
         metadata={
             "validator": lambda val: validate_and(
                 [
-                    lambda v: validate_instance_of(v, list),
-                    lambda v: validate_list_of(v, VariantFeatureConfig),
+                    lambda v: validate_type(v, list[VariantFeatureConfig]),
                     lambda v: validate_list_min_len(v, 1),
                     lambda v: validate_list_all_unique(v, key=attrgetter("name")),
                 ],

--- a/variantlib/models/validators.py
+++ b/variantlib/models/validators.py
@@ -6,6 +6,7 @@ from collections.abc import Iterable
 from types import GenericAlias
 from typing import Any
 from typing import Callable
+from typing import Union
 from typing import get_args
 from typing import get_origin
 
@@ -112,9 +113,7 @@ def validate_type(value: Any, expected_type: type) -> None:
             type(item) for item in value if not isinstance(item, item_type)
         }
         if incorrect_types:
-            ored = item_type
-            while incorrect_types:
-                ored |= incorrect_types.pop()
+            ored = Union.__getitem__((item_type, *incorrect_types))
             wrong_type = list_type[ored]  # type: ignore[index]
             raise ValidationError(f"Expected {expected_type}, got {wrong_type}")
     elif not isinstance(value, expected_type):

--- a/variantlib/models/validators.py
+++ b/variantlib/models/validators.py
@@ -14,20 +14,9 @@ from variantlib.errors import ValidationError
 logger = logging.getLogger(__name__)
 
 
-def validate_instance_of(value: Any, expected_type: type) -> None:
-    if not isinstance(value, expected_type):
-        raise ValidationError(f"Expected {expected_type}, got {type(value)}")
-
-
 def validate_matches_re(value: str, pattern: str) -> None:
     if not re.match(pattern, value):
         raise ValidationError(f"Value `{value}` must match regex {pattern}")
-
-
-def validate_list_of(values: Iterable[Any], expected_type: type) -> None:
-    for value in values:
-        if not isinstance(value, expected_type):
-            raise ValidationError(f"Expected {expected_type}, got {type(value)}")
 
 
 def validate_list_matches_re(values: list[str], pattern: str) -> None:

--- a/variantlib/models/variant.py
+++ b/variantlib/models/variant.py
@@ -16,11 +16,10 @@ from variantlib.constants import VARIANT_HASH_LEN
 from variantlib.errors import ValidationError
 from variantlib.models.base import BaseModel
 from variantlib.models.validators import validate_and
-from variantlib.models.validators import validate_instance_of
 from variantlib.models.validators import validate_list_all_unique
 from variantlib.models.validators import validate_list_min_len
-from variantlib.models.validators import validate_list_of
 from variantlib.models.validators import validate_matches_re
+from variantlib.models.validators import validate_type
 
 if sys.version_info >= (3, 11):
     from typing import Self
@@ -34,7 +33,7 @@ class VariantFeature(BaseModel):
         metadata={
             "validator": lambda val: validate_and(
                 [
-                    lambda v: validate_instance_of(v, str),
+                    lambda v: validate_type(v, str),
                     lambda v: validate_matches_re(v, VALIDATION_NAMESPACE_REGEX),
                 ],
                 value=val,
@@ -45,7 +44,7 @@ class VariantFeature(BaseModel):
         metadata={
             "validator": lambda val: validate_and(
                 [
-                    lambda v: validate_instance_of(v, str),
+                    lambda v: validate_type(v, str),
                     lambda v: validate_matches_re(v, VALIDATION_FEATURE_REGEX),
                 ],
                 value=val,
@@ -104,7 +103,7 @@ class VariantProperty(VariantFeature):
         metadata={
             "validator": lambda val: validate_and(
                 [
-                    lambda v: validate_instance_of(v, str),
+                    lambda v: validate_type(v, str),
                     lambda v: validate_matches_re(v, VALIDATION_VALUE_REGEX),
                 ],
                 value=val,
@@ -163,8 +162,7 @@ class VariantDescription(BaseModel):
         metadata={
             "validator": lambda val: validate_and(
                 [
-                    lambda v: validate_instance_of(v, list),
-                    lambda v: validate_list_of(v, VariantProperty),
+                    lambda v: validate_type(v, list[VariantProperty]),
                     lambda v: validate_list_min_len(v, 1),
                     lambda v: validate_list_all_unique(
                         v, key=attrgetter("feature_hash")


### PR DESCRIPTION
Now any error to load or instantiate a plugin, or invalid return value will trigger an explicit exception. I've also covered all the cases I could think of.

I've assumed that the entry point is allowed to return any callable that instantiates into `PluginType` class rather than the class type itself.

This also comes with a `validate_type` function that replaces separate `validate_instance_of` and `validate_list_of` calls. The next step would be inferring types straight from dataclasses but that's a followup item, and I'm not sure if it'll be doable cross-module.

I've filed https://github.com/python/mypy/issues/18894 for the `type: ignore`, but I'm not sure if it's feasible to fix on mypy end.