### PR TITLE
Add convenience getters in validation result

### DIFF
--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -65,6 +65,27 @@ def test_validation_result_is_valid(
     assert res.is_valid(allow_unknown_plugins=False) == valid_strict
 
 
+def test_validation_result_properties():
+    res = VariantValidationResult(
+        {
+            VariantProperty("blas", "variant", "mkl"): True,
+            VariantProperty("cuda", "runtime", "12.0"): None,
+            VariantProperty("blas", "invariant", "lkm"): False,
+            VariantProperty("x86_64", "baseline", "v10"): False,
+            VariantProperty("orange", "juice", "good"): None,
+        }
+    )
+
+    assert res.invalid_properties == [
+        VariantProperty("blas", "invariant", "lkm"),
+        VariantProperty("x86_64", "baseline", "v10"),
+    ]
+    assert res.unknown_properties == [
+        VariantProperty("cuda", "runtime", "12.0"),
+        VariantProperty("orange", "juice", "good"),
+    ]
+
+
 def test_validate_variant(mocked_plugin_loader: type[PluginLoader]):  # noqa: F811
     res = validate_variant(
         VariantDescription(

--- a/variantlib/models/variant.py
+++ b/variantlib/models/variant.py
@@ -229,3 +229,13 @@ class VariantValidationResult:
         return False not in self.results.values() and (
             allow_unknown_plugins or None not in self.results.values()
         )
+
+    @property
+    def invalid_properties(self) -> list[VariantProperty]:
+        """List of properties declared invalid by plugins"""
+        return [x for x, y in self.results.items() if y is False]
+
+    @property
+    def unknown_properties(self) -> list[VariantProperty]:
+        """List of properties not in any recognized namespace"""
+        return [x for x, y in self.results.items() if y is None]


### PR DESCRIPTION
Add convenience getters to get invalid and unknown properties from a validation result.