### PR TITLE
Initial sketch of get_build_setup() API

### DIFF
--- a/tests/test_plugins.py
+++ b/tests/test_plugins.py
@@ -49,6 +49,7 @@ class MockedPluginA(PluginType):
                 return {
                     "cflags": [f"-march={prop.value}"],
                     "cxxflags": [f"-march={prop.value}"],
+                    "ldflags": ["-Wl,--test-flag"],
                 }
         return {}
 
@@ -452,6 +453,7 @@ def test_get_build_setup(mocked_plugin_loader):
     assert mocked_plugin_loader.get_build_setup(variant_desc) == {
         "cflags": ["-mflag1", "-mflag4", "-march=val1b"],
         "cxxflags": ["-mflag1", "-mflag4", "-march=val1b"],
+        "ldflags": ["-Wl,--test-flag"],
     }
 
 

--- a/tests/test_plugins.py
+++ b/tests/test_plugins.py
@@ -40,13 +40,15 @@ class MockedPluginA(PluginType):
             VariantFeatureConfig("name2", ["val2a", "val2b", "val2c"]),
         ]
 
-    def get_build_setup(self, properties: list[VariantPropertyType]) -> dict[str, str]:
+    def get_build_setup(
+        self, properties: list[VariantPropertyType]
+    ) -> dict[str, list[str]]:
         for prop in properties:
             assert prop.namespace == self.namespace
             if prop.feature == "name1":
                 return {
-                    "cflags": f"-march={prop.value}",
-                    "cxxflags": f"-march={prop.value}",
+                    "cflags": [f"-march={prop.value}"],
+                    "cxxflags": [f"-march={prop.value}"],
                 }
         return {}
 
@@ -93,7 +95,9 @@ class MockedPluginC(PluginType):
     def get_supported_configs(self) -> list[VariantFeatureConfigType]:
         return []
 
-    def get_build_setup(self, properties: list[VariantPropertyType]) -> dict[str, str]:
+    def get_build_setup(
+        self, properties: list[VariantPropertyType]
+    ) -> dict[str, list[str]]:
         flag_opts = []
 
         for prop in properties:
@@ -102,8 +106,8 @@ class MockedPluginC(PluginType):
             flag_opts.append(f"-m{prop.feature}")
 
         return {
-            "cflags": " ".join(flag_opts),
-            "cxxflags": " ".join(flag_opts),
+            "cflags": flag_opts,
+            "cxxflags": flag_opts,
         }
 
 
@@ -446,8 +450,8 @@ def test_get_build_setup(mocked_plugin_loader):
     )
 
     assert mocked_plugin_loader.get_build_setup(variant_desc) == {
-        "cflags": "-mflag1 -mflag4 -march=val1b",
-        "cxxflags": "-mflag1 -mflag4 -march=val1b",
+        "cflags": ["-mflag1", "-mflag4", "-march=val1b"],
+        "cxxflags": ["-mflag1", "-mflag4", "-march=val1b"],
     }
 
 

--- a/variantlib/base.py
+++ b/variantlib/base.py
@@ -65,6 +65,8 @@ class PluginType(Protocol):
         """Get supported configs for the current system"""
         raise NotImplementedError
 
-    def get_build_setup(self, properties: list[VariantPropertyType]) -> dict[str, str]:
+    def get_build_setup(
+        self, properties: list[VariantPropertyType]
+    ) -> dict[str, list[str]]:
         """Get build variables for a variant made of specified properties"""
         return {}

--- a/variantlib/base.py
+++ b/variantlib/base.py
@@ -23,6 +23,29 @@ class VariantFeatureConfigType(Protocol):
 
 
 @runtime_checkable
+class VariantPropertyType(Protocol):
+    """A protocol for variant properties"""
+
+    @property
+    @abstractmethod
+    def namespace(self) -> str:
+        """Namespace (from plugin)"""
+        raise NotImplementedError
+
+    @property
+    @abstractmethod
+    def feature(self) -> str:
+        """Feature name (within the namespace)"""
+        raise NotImplementedError
+
+    @property
+    @abstractmethod
+    def value(self) -> str:
+        """Feature value"""
+        raise NotImplementedError
+
+
+@runtime_checkable
 class PluginType(Protocol):
     """A protocol for plugin classes"""
 
@@ -41,3 +64,7 @@ class PluginType(Protocol):
     def get_supported_configs(self) -> list[VariantFeatureConfigType]:
         """Get supported configs for the current system"""
         raise NotImplementedError
+
+    def get_build_setup(self, properties: list[VariantPropertyType]) -> dict[str, str]:
+        """Get build variables for a variant made of specified properties"""
+        return {}

--- a/variantlib/errors.py
+++ b/variantlib/errors.py
@@ -3,4 +3,8 @@ class ValidationError(ValueError):
 
 
 class PluginError(RuntimeError):
-    pass
+    """Incorrect plugin implementation"""
+
+
+class PluginMissingError(RuntimeError):
+    """A required plugin is missing"""

--- a/variantlib/loader.py
+++ b/variantlib/loader.py
@@ -190,11 +190,11 @@ class PluginLoader:
         return provider_cfgs
 
     @classmethod
-    def get_build_setup(cls, properties: VariantDescription) -> dict[str, str]:
+    def get_build_setup(cls, properties: VariantDescription) -> dict[str, list[str]]:
         """Get build variables for a variant made of specified properties"""
         cls.load_plugins()
 
-        ret_env: dict[str, str] = {}
+        ret_env: dict[str, list[str]] = {}
         for namespace, p_props in groupby(
             sorted(properties.properties), lambda prop: prop.namespace
         ):
@@ -205,7 +205,7 @@ class PluginLoader:
                 plugin_env = plugin.get_build_setup(list(p_props))
 
                 try:
-                    validate_type(plugin_env, dict[str, str])
+                    validate_type(plugin_env, dict[str, list[str]])
                 except ValidationError as err:
                     raise TypeError(
                         f"Provider {namespace}, get_build_setup() "
@@ -215,10 +215,7 @@ class PluginLoader:
                 plugin_env = {}
 
             for k, v in plugin_env.items():
-                if k in ret_env:
-                    ret_env[k] += f" {v}"
-                else:
-                    ret_env[k] = v
+                ret_env.setdefault(k, []).extend(v)
         return ret_env
 
     @classproperty

--- a/variantlib/loader.py
+++ b/variantlib/loader.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import logging
 import sys
+from itertools import groupby
 from types import MethodType
 from typing import TYPE_CHECKING
 from typing import Any
@@ -9,6 +10,7 @@ from typing import get_type_hints
 
 from variantlib.base import PluginType
 from variantlib.errors import PluginError
+from variantlib.errors import PluginMissingError
 from variantlib.models.provider import ProviderConfig
 from variantlib.models.provider import VariantFeatureConfig
 from variantlib.models.validators import ValidationError
@@ -27,6 +29,8 @@ else:
 
 if TYPE_CHECKING:
     from typing import Callable
+
+    from variantlib.models.variant import VariantDescription
 
 logger = logging.getLogger(__name__)
 
@@ -184,6 +188,38 @@ class PluginLoader:
             )
 
         return provider_cfgs
+
+    @classmethod
+    def get_build_setup(cls, properties: VariantDescription) -> dict[str, str]:
+        """Get build variables for a variant made of specified properties"""
+        cls.load_plugins()
+
+        ret_env: dict[str, str] = {}
+        for namespace, p_props in groupby(
+            sorted(properties.properties), lambda prop: prop.namespace
+        ):
+            if (plugin := cls._plugins.get(namespace)) is None:
+                raise PluginMissingError(f"No plugin found for namespace {namespace}")
+
+            if hasattr(plugin, "get_build_setup"):
+                plugin_env = plugin.get_build_setup(list(p_props))
+
+                try:
+                    validate_type(plugin_env, dict[str, str])
+                except ValidationError as err:
+                    raise TypeError(
+                        f"Provider {namespace}, get_build_setup() "
+                        f"method returned incorrect type. {err}"
+                    ) from None
+            else:
+                plugin_env = {}
+
+            for k, v in plugin_env.items():
+                if k in ret_env:
+                    ret_env[k] += f" {v}"
+                else:
+                    ret_env[k] = v
+        return ret_env
 
     @classproperty
     def distribution_names(cls) -> dict[str, str]:  # noqa: N805


### PR DESCRIPTION
Initial sketch of API to get variables specific to build environment. The plugin method takes a list of variant properties (variantlib filters them, so that only properties specific to given plugin are passed) and returns a dict[str, str] of variables.  If two or more plugins return the same key, the values are concatenated.

This also includes improvement to validate_type() to handle dict types. I still need to streamline that function, and ideally make it able to handle arbitrary type nesting.

I also need to add tests for invalid values.

TODO: should we retur `dict[str, list[str]]` instead perhaps?  That would probably be nicer to build systems like Meson, and it would also make concatenating cleaner.