### PR TITLE
Separated improvements from #29

### DIFF
--- a/tests/models/test_validators.py
+++ b/tests/models/test_validators.py
@@ -1,6 +1,5 @@
 import re
 from dataclasses import dataclass
-from types import NoneType
 from typing import Any
 from typing import Protocol
 from typing import Union
@@ -34,7 +33,7 @@ class MyClass(HalfClass):
 @pytest.mark.parametrize(
     ("value", "expected"),
     [
-        (None, NoneType),
+        (None, type(None)),
         (False, bool),
         (11, int),
         (4.5, float),
@@ -58,7 +57,7 @@ def test_validate_type_good(value: Any, expected: type):
 @pytest.mark.parametrize(
     ("value", "expected", "have"),
     [
-        (None, bool, NoneType),
+        (None, bool, type(None)),
         (False, str, bool),
         (11, float, int),
         (4.5, int, float),

--- a/tests/models/test_validators.py
+++ b/tests/models/test_validators.py
@@ -45,6 +45,8 @@ class MyClass(HalfClass):
         ({1, 2, 3}, set[int]),
         (set(), set[int]),
         (MyClass(1, "2"), MyProtocol),
+        ([[1], [2, 3], [4, 5]], list[list[int]]),
+        ([[[1], [2, 3], [4, 5]]], list[list[list[int]]]),
     ],
 )
 def test_validate_type_good(value: Any, expected: type):
@@ -70,6 +72,18 @@ def test_validate_type_good(value: Any, expected: type):
         (object(), MyProtocol, object),
         ({"a": 1, "b": "2"}, MyProtocol, dict),
         (HalfClass(1), MyProtocol, HalfClass),
+        (
+            [[1], ["2", 3], ["4", "5"]],
+            list[list[int]],
+            list[Union[list[int], list[Union[int, str]]]],
+        ),
+        ([[1], {2, 3}, [4, 5]], list[list[int]], list[Union[list[int], set]]),
+        ([1, 2, 3], list[list[int]], list[Union[list[int], int]]),
+        (
+            [[[1], [2, "3"], ["4", 5]]],
+            list[list[list[int]]],
+            list[Union[list[list[int]], list[Union[list[int], list[Union[int, str]]]]]],
+        ),
     ],
 )
 def test_validate_type_bad(value: Any, expected: type, have: type):

--- a/tests/models/test_validators.py
+++ b/tests/models/test_validators.py
@@ -1,0 +1,79 @@
+import re
+from dataclasses import dataclass
+from types import NoneType
+from typing import Any
+from typing import Protocol
+from typing import Union
+from typing import runtime_checkable
+
+import pytest
+
+from variantlib.models.validators import ValidationError
+from variantlib.models.validators import validate_type
+
+
+@runtime_checkable
+class MyProtocol(Protocol):
+    @property
+    def a(self) -> int: ...
+
+    @property
+    def b(self) -> str: ...
+
+
+@dataclass
+class HalfClass:
+    a: int
+
+
+@dataclass
+class MyClass(HalfClass):
+    b: str
+
+
+@pytest.mark.parametrize(
+    ("value", "expected"),
+    [
+        (None, NoneType),
+        (False, bool),
+        (11, int),
+        (4.5, float),
+        (b"foo", bytes),
+        ("foo", str),
+        ([1, 2, 3], list[int]),
+        ([], list[int]),
+        ({1, 2, 3}, set[int]),
+        (set(), set[int]),
+        (MyClass(1, "2"), MyProtocol),
+    ],
+)
+def test_validate_type_good(value: Any, expected: type):
+    validate_type(value, expected)
+
+
+@pytest.mark.parametrize(
+    ("value", "expected", "have"),
+    [
+        (None, bool, NoneType),
+        (False, str, bool),
+        (11, float, int),
+        (4.5, int, float),
+        (b"foo", str, bytes),
+        ("foo", bytes, str),
+        ([1, 2, 3], set[int], list),
+        ([1, 2, 3], list[str], list[Union[str, int]]),
+        (["1", 2, "3"], list[str], list[Union[str, int]]),
+        ({1, 2, 3}, list[int], set),
+        ({1, 2, 3}, set[str], set[Union[str, int]]),
+        ({"1", 2, "3"}, set[str], set[Union[str, int]]),
+        (11, MyProtocol, int),
+        (object(), MyProtocol, object),
+        ({"a": 1, "b": "2"}, MyProtocol, dict),
+        (HalfClass(1), MyProtocol, HalfClass),
+    ],
+)
+def test_validate_type_bad(value: Any, expected: type, have: type):
+    with pytest.raises(
+        ValidationError, match=re.escape(f"Expected {expected}, got {have}")
+    ):
+        validate_type(value, expected)

--- a/tests/models/test_validators.py
+++ b/tests/models/test_validators.py
@@ -47,6 +47,8 @@ class MyClass(HalfClass):
         (MyClass(1, "2"), MyProtocol),
         ([[1], [2, 3], [4, 5]], list[list[int]]),
         ([[[1], [2, 3], [4, 5]]], list[list[list[int]]]),
+        ({"a": 1, "b": 2}, dict[str, int]),
+        ({"a": [1, 2, 3], "b": [4]}, dict[str, list[int]]),
     ],
 )
 def test_validate_type_good(value: Any, expected: type):
@@ -83,6 +85,17 @@ def test_validate_type_good(value: Any, expected: type):
             [[[1], [2, "3"], ["4", 5]]],
             list[list[list[int]]],
             list[Union[list[list[int]], list[Union[list[int], list[Union[int, str]]]]]],
+        ),
+        ({"a": "1", "b": 2}, dict[str, int], dict[str, Union[int, str]]),
+        (
+            {"a": [1, "2", 3], "b": ["4"]},
+            dict[str, list[int]],
+            dict[str, Union[list[int], list[Union[int, str]]]],
+        ),
+        (
+            {"a": [1, 2, 3], "b": 4},
+            dict[str, list[int]],
+            dict[str, Union[list[int], int]],
         ),
     ],
 )

--- a/tests/models/test_variant.py
+++ b/tests/models/test_variant.py
@@ -188,6 +188,34 @@ def test_variantprop_deserialization():
     assert vprop.value == data["value"]
 
 
+def test_variantprop_sorting():
+    data = [
+        VariantProperty("z", "a", "a"),
+        VariantProperty("z", "a", "b"),
+        VariantProperty("a", "b", "a"),
+        VariantProperty("a", "a", "a"),
+        VariantProperty("a", "a", "z"),
+        VariantProperty("c", "x", "a"),
+        VariantProperty("z", "a", "a"),
+        VariantProperty("b", "b", "a"),
+        VariantProperty("b", "b", "b"),
+        VariantProperty("z", "b", "a"),
+    ]
+
+    assert sorted(data) == [
+        VariantProperty("a", "a", "a"),
+        VariantProperty("a", "a", "z"),
+        VariantProperty("a", "b", "a"),
+        VariantProperty("b", "b", "a"),
+        VariantProperty("b", "b", "b"),
+        VariantProperty("c", "x", "a"),
+        VariantProperty("z", "a", "a"),
+        VariantProperty("z", "a", "a"),
+        VariantProperty("z", "a", "b"),
+        VariantProperty("z", "b", "a"),
+    ]
+
+
 # -----------------------------------------------
 # Test for VariantDescription Class
 # -----------------------------------------------

--- a/tests/test_plugins.py
+++ b/tests/test_plugins.py
@@ -400,8 +400,9 @@ def test_plugin_instantiation_returns_incorrect_type(cls: type, mocker):
 
     with pytest.raises(
         PluginError,
-        match="Instantiating the plugin from entry point exception_test returned "
-        "an object that does not meet the PluginType prototype: "
-        "<tests.test_plugins.IncompletePlugin object at .*>",
+        match=r"Instantiating the plugin from entry point exception_test returned "
+        r"an object that does not meet the PluginType prototype: "
+        r"<tests.test_plugins.IncompletePlugin object at .*> "
+        r"\(missing attributes: get_all_configs\)",
     ):
         PluginLoader.load_plugins()

--- a/variantlib/loader.py
+++ b/variantlib/loader.py
@@ -92,11 +92,15 @@ class PluginLoader:
                     f"{exc}"
                 ) from exc
 
-            if not isinstance(plugin_instance, PluginType):
+            required_attributes = PluginType.__abstractmethods__
+            if missing_attributes := required_attributes.difference(
+                dir(plugin_instance)
+            ):
                 raise PluginError(
                     f"Instantiating the plugin from entry point {plugin.name} "
                     "returned an object that does not meet the PluginType prototype: "
-                    f"{plugin_instance!r}"
+                    f"{plugin_instance!r} (missing attributes: "
+                    f"{', '.join(sorted(missing_attributes))})"
                 )
 
             if plugin_instance.namespace in cls._plugins:

--- a/variantlib/models/variant.py
+++ b/variantlib/models/variant.py
@@ -27,7 +27,7 @@ else:
     from typing_extensions import Self
 
 
-@dataclass(frozen=True)
+@dataclass(frozen=True, order=True)
 class VariantFeature(BaseModel):
     namespace: str = field(
         metadata={
@@ -97,7 +97,7 @@ class VariantFeature(BaseModel):
         return cls(namespace=namespace, feature=feature)
 
 
-@dataclass(frozen=True)
+@dataclass(frozen=True, order=True)
 class VariantProperty(VariantFeature):
     value: str = field(
         metadata={
@@ -180,11 +180,7 @@ class VariantDescription(BaseModel):
 
         with contextlib.suppress(AttributeError):
             # Only "legal way" to modify a frozen dataclass attribute post init.
-            object.__setattr__(
-                self,
-                "properties",
-                sorted(self.properties, key=lambda x: (x.namespace, x.feature)),
-            )
+            object.__setattr__(self, "properties", sorted(self.properties))
 
         # Execute the validator
         super().__post_init__()


### PR DESCRIPTION
Focused on getting the internal improvements in, independently of #29:

- validate `PluginType` manually rather than via `isinstance()`, giving future support for optional methods and better error messages today
- support sorting `VariantFeature` and `VariantProperty` directly
- add unit tests to `validate_type()`
- support validating dicts in `validate_type()`
- support validating recursive types in `validate_types()` (e.g. `dict[str, list[str]]`)