### PR TITLE
Support for evaluating "variants" environment specifiers

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -30,6 +30,7 @@ maintainers = [
 ]
 dependencies = [
     "importlib-metadata; python_version < '3.10'",
+    "packaging",
     "typing-extensions; python_version < '3.11'",
 ]
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -30,7 +30,6 @@ maintainers = [
 ]
 dependencies = [
     "importlib-metadata; python_version < '3.10'",
-    "packaging",
     "typing-extensions; python_version < '3.11'",
 ]
 

--- a/tests/test_envspec.py
+++ b/tests/test_envspec.py
@@ -1,5 +1,7 @@
 import pytest
 
+from variantlib.envspec import FALSE_STR
+from variantlib.envspec import TRUE_STR
 from variantlib.envspec import evaluate_variant_requirements
 from variantlib.errors import InvalidVariantEnvSpecError
 from variantlib.models.variant import VariantDescription
@@ -9,35 +11,41 @@ from variantlib.models.variant import VariantProperty
 @pytest.mark.parametrize(
     ("properties", "expected"),
     [
-        ([VariantProperty("x86_64", "level", "v3")], ["variant-x86-64"]),
-        ([VariantProperty("x86_64", "sse3", "on")], ["variant-x86-64"]),
-        ([VariantProperty("cuda", "runtime", "12.6")], ["variant-cuda"]),
-        ([VariantProperty("cuda", "other", "x")], []),
-        ([VariantProperty("x", "y", "z")], []),
+        ([VariantProperty("x86_64", "level", "v3")], [False, True, False]),
+        ([VariantProperty("x86_64", "sse3", "on")], [False, True, False]),
+        ([VariantProperty("cuda", "runtime", "12.6")], [True, False, True]),
+        ([VariantProperty("cuda", "other", "x")], [False, False, True]),
+        ([VariantProperty("x", "y", "z")], [False, False, False]),
         (
             [
                 VariantProperty("x86_64", "level", "v3"),
                 VariantProperty("cuda", "runtime", "12.6"),
             ],
-            ["variant-cuda", "variant-x86-64"],
+            [True, True, True],
         ),
     ],
 )
 def test_evaluate_variant_requirements(
-    properties: list[VariantProperty], expected: list[str]
+    properties: list[VariantProperty], expected: list[bool]
 ) -> None:
     requirements = [
         "setuptools",
         "typing-extensions; python_version < '3.11'",
         "variant-cuda; 'cuda :: runtime' in variants",
         "variant-x86-64; 'x86_64' in variants",
+        "variant-cuda-extra; 'cuda' in variants and python_version >= '3.11'",
+        "no-cuda; 'cuda' not in variants",
     ]
     variant_desc = VariantDescription(properties)
 
     assert evaluate_variant_requirements(requirements, variant_desc) == [
         "setuptools",
         "typing-extensions; python_version < '3.11'",
-        *expected,
+        f"variant-cuda; {TRUE_STR if expected[0] else FALSE_STR}",
+        f"variant-x86-64; {TRUE_STR if expected[1] else FALSE_STR}",
+        f"variant-cuda-extra; {TRUE_STR if expected[2] else FALSE_STR} "
+        'and python_version >= "3.11"',
+        f"no-cuda; {TRUE_STR if not expected[2] else FALSE_STR}",
     ]
 
 
@@ -46,7 +54,12 @@ def test_evaluate_variant_requirements(
     [
         "variants == 'x'",
         "variants in 'x'",
+        "variants not in 'x'",
         "'x' == variants",
+        "variants!='x'",
+        "variants in'x'",
+        "variants not in'x'",
+        "'x'!=variants",
     ],
 )
 def test_invalid_variant_requirements(env_spec: str) -> None:

--- a/tests/test_envspec.py
+++ b/tests/test_envspec.py
@@ -60,6 +60,12 @@ def test_evaluate_variant_requirements(
         "variants in'x'",
         "variants not in'x'",
         "'x'!=variants",
+        "variants < 'x'",
+        "variants~='x'",
+        "variants>='x'",
+        "'x'~=variants",
+        "'x'>   variants",
+        "'x'   >=variants",
     ],
 )
 def test_invalid_variant_requirements(env_spec: str) -> None:

--- a/tests/test_envspec.py
+++ b/tests/test_envspec.py
@@ -44,7 +44,7 @@ def test_evaluate_variant_requirements(
         f"variant-cuda; {TRUE_STR if expected[0] else FALSE_STR}",
         f"variant-x86-64; {TRUE_STR if expected[1] else FALSE_STR}",
         f"variant-cuda-extra; {TRUE_STR if expected[2] else FALSE_STR} "
-        'and python_version >= "3.11"',
+        "and python_version >= '3.11'",
         f"no-cuda; {TRUE_STR if not expected[2] else FALSE_STR}",
     ]
 

--- a/tests/test_envspec.py
+++ b/tests/test_envspec.py
@@ -1,0 +1,57 @@
+import pytest
+
+from variantlib.envspec import evaluate_variant_requirements
+from variantlib.errors import InvalidVariantEnvSpecError
+from variantlib.models.variant import VariantDescription
+from variantlib.models.variant import VariantProperty
+
+
+@pytest.mark.parametrize(
+    ("properties", "expected"),
+    [
+        ([VariantProperty("x86_64", "level", "v3")], ["variant-x86-64"]),
+        ([VariantProperty("x86_64", "sse3", "on")], ["variant-x86-64"]),
+        ([VariantProperty("cuda", "runtime", "12.6")], ["variant-cuda"]),
+        ([VariantProperty("cuda", "other", "x")], []),
+        ([VariantProperty("x", "y", "z")], []),
+        (
+            [
+                VariantProperty("x86_64", "level", "v3"),
+                VariantProperty("cuda", "runtime", "12.6"),
+            ],
+            ["variant-cuda", "variant-x86-64"],
+        ),
+    ],
+)
+def test_evaluate_variant_requirements(
+    properties: list[VariantProperty], expected: list[str]
+) -> None:
+    requirements = [
+        "setuptools",
+        "typing-extensions; python_version < '3.11'",
+        "variant-cuda; 'cuda :: runtime' in variants",
+        "variant-x86-64; 'x86_64' in variants",
+    ]
+    variant_desc = VariantDescription(properties)
+
+    assert evaluate_variant_requirements(requirements, variant_desc) == [
+        "setuptools",
+        "typing-extensions; python_version < '3.11'",
+        *expected,
+    ]
+
+
+@pytest.mark.parametrize(
+    "env_spec",
+    [
+        "variants == 'x'",
+        "variants in 'x'",
+        "'x' == variants",
+    ],
+)
+def test_invalid_variant_requirements(env_spec: str) -> None:
+    with pytest.raises(InvalidVariantEnvSpecError):
+        evaluate_variant_requirements(
+            [f"variant-test; {env_spec}"],
+            VariantDescription([VariantProperty("x", "y", "z")]),
+        )

--- a/tests/test_envspec.py
+++ b/tests/test_envspec.py
@@ -4,7 +4,6 @@ from variantlib.envspec import FALSE_STR
 from variantlib.envspec import TRUE_STR
 from variantlib.envspec import evaluate_variant_requirements
 from variantlib.errors import InvalidVariantEnvSpecError
-from variantlib.models.variant import VariantDescription
 from variantlib.models.variant import VariantProperty
 
 
@@ -23,6 +22,7 @@ from variantlib.models.variant import VariantProperty
             ],
             [True, True, True],
         ),
+        ([], [False, False, False]),
     ],
 )
 def test_evaluate_variant_requirements(
@@ -36,9 +36,8 @@ def test_evaluate_variant_requirements(
         "variant-cuda-extra; 'cuda' in variants and python_version >= '3.11'",
         "no-cuda; 'cuda' not in variants",
     ]
-    variant_desc = VariantDescription(properties)
 
-    assert evaluate_variant_requirements(requirements, variant_desc) == [
+    assert evaluate_variant_requirements(requirements, properties) == [
         "setuptools",
         "typing-extensions; python_version < '3.11'",
         f"variant-cuda; {TRUE_STR if expected[0] else FALSE_STR}",
@@ -72,5 +71,5 @@ def test_invalid_variant_requirements(env_spec: str) -> None:
     with pytest.raises(InvalidVariantEnvSpecError):
         evaluate_variant_requirements(
             [f"variant-test; {env_spec}"],
-            VariantDescription([VariantProperty("x", "y", "z")]),
+            [VariantProperty("x", "y", "z")],
         )

--- a/variantlib/envspec.py
+++ b/variantlib/envspec.py
@@ -2,15 +2,31 @@
 
 from __future__ import annotations
 
+import re
 from itertools import chain
 
-from packaging.markers import Op
-from packaging.markers import Value
-from packaging.markers import Variable
 from packaging.requirements import Requirement
 from variantlib.errors import InvalidVariantEnvSpecError
 from variantlib.models.variant import VariantDescription
 from variantlib.models.variant import VariantFeature
+
+TRUE_STR = "python_version != '0'"
+FALSE_STR = "python_version == '0'"
+
+VARIANT_EXPR_RE = re.compile(
+    # 'value' in variants
+    r"(?P<quote>[\"'])(?P<value>.*)(?P=quote) \s* (?P<neg>not \s+)? in \s+ variants\b",
+    re.VERBOSE,
+)
+
+VARIANT_ERROR_RES = [
+    # variants OP ...
+    re.compile(r"\bvariants \s* [=!<>]", re.VERBOSE),
+    # variants [not] in ...
+    re.compile(r"\bvariants \s+ (not \s+)? in", re.VERBOSE),
+    # ... OP variants ; where OP != "in"
+    re.compile(r"[=!<>] \s* variants", re.VERBOSE),
+]
 
 
 def evaluate_variant_requirements(
@@ -39,39 +55,26 @@ def evaluate_variant_requirements(
     new_requirements = []
     for req in requirements:
         parsed_req = Requirement(req)
-        marker = parsed_req.marker
-        # TODO: support more complex markers
-        if marker is None or len(marker._markers) != 1:  # noqa: SLF001
-            new_requirements.append(req)
-            continue
 
-        parsed_marker = marker._markers[0]  # noqa: SLF001
-        assert isinstance(parsed_marker[1], Op)
-        # "variants OP ..." is invalid
-        if (
-            isinstance(parsed_marker[0], Variable)
-            and str(parsed_marker[0]) == "variants"
-        ):
-            raise InvalidVariantEnvSpecError(
-                "'variants' marker can only be used in \"'foo' in variants\" "
-                "expressions"
-            )
-        # we are only interested in "... OP variants"
-        if not (
-            isinstance(parsed_marker[2], Variable)
-            and str(parsed_marker[2]) == "variants"
-        ):
-            new_requirements.append(req)
-            continue
-        # only "in" operator is allowed
-        if str(parsed_marker[1]) != "in" or not isinstance(parsed_marker[0], Value):
-            raise InvalidVariantEnvSpecError(
-                "'variants' marker can only be used in \"'foo' in variants\" "
-                "expressions"
-            )
+        def repl(match: re.Match) -> str:
+            if (match.group("neg") is None) == (match.group("value") in all_values):
+                return TRUE_STR
+            return FALSE_STR
 
-        if str(parsed_marker[0]) in all_values:
-            parsed_req.marker = None
-            new_requirements.append(str(parsed_req))
+        if parsed_req.marker is not None:
+            for error_re in VARIANT_ERROR_RES:
+                if error_re.search(str(parsed_req.marker)) is not None:
+                    raise InvalidVariantEnvSpecError(
+                        "'variants' marker can only be used in \"'foo' in variants\" "
+                        "expressions"
+                    )
+
+            new_marker = VARIANT_EXPR_RE.sub(repl, str(parsed_req.marker))
+            # alter the requirement only if we actually changed anything
+            if new_marker != str(parsed_req.marker):
+                parsed_req.marker = new_marker
+                new_requirements.append(str(parsed_req))
+                continue
+        new_requirements.append(req)
 
     return new_requirements

--- a/variantlib/envspec.py
+++ b/variantlib/envspec.py
@@ -21,7 +21,7 @@ VARIANT_EXPR_RE = re.compile(
 VARIANT_ERROR_RE = re.compile(
     r"("
     # variants OP ...
-    r"\b variants \s* ([=!<>] | \s (not \s+)? in) |"
+    r"\b variants \s* ([~=!<>] | \s (not \s+)? in) |"
     # ... OP variants ; where OP != "in"
     r"[=!<>] \s* variants\b"
     r")",

--- a/variantlib/envspec.py
+++ b/variantlib/envspec.py
@@ -6,8 +6,8 @@ import re
 from itertools import chain
 
 from variantlib.errors import InvalidVariantEnvSpecError
-from variantlib.models.variant import VariantDescription
 from variantlib.models.variant import VariantFeature
+from variantlib.models.variant import VariantProperty
 
 TRUE_STR = "python_version != '0'"
 FALSE_STR = "python_version == '0'"
@@ -30,7 +30,7 @@ VARIANT_ERROR_RE = re.compile(
 
 
 def evaluate_variant_requirements(
-    requirements: list[str], variant_desc: VariantDescription
+    requirements: list[str], variant_properties: list[VariantProperty]
 ) -> list[str]:
     """
     Evaluate variant requirements in specified requirement strings
@@ -48,7 +48,7 @@ def evaluate_variant_requirements(
                 VariantFeature(x.namespace, x.feature).to_str(),
                 x.namespace,
             )
-            for x in variant_desc.properties
+            for x in variant_properties
         )
     )
 

--- a/variantlib/envspec.py
+++ b/variantlib/envspec.py
@@ -1,0 +1,77 @@
+"""Support for processing "variants" environment specifier"""
+
+from __future__ import annotations
+
+from itertools import chain
+
+from packaging.markers import Op
+from packaging.markers import Value
+from packaging.markers import Variable
+from packaging.requirements import Requirement
+from variantlib.errors import InvalidVariantEnvSpecError
+from variantlib.models.variant import VariantDescription
+from variantlib.models.variant import VariantFeature
+
+
+def evaluate_variant_requirements(
+    requirements: list[str], variant_desc: VariantDescription
+) -> list[str]:
+    """
+    Evaluate variant requirements in specified requirement strings
+
+    Evaluate the variant requirements found in the specified requirement
+    strings against the described variant,  Returns the requirements
+    modified according to the evaluated variants, with other environment
+    specifiers unchanged.
+    """
+
+    all_values = frozenset(
+        chain.from_iterable(
+            (
+                x.to_str(),
+                VariantFeature(x.namespace, x.feature).to_str(),
+                x.namespace,
+            )
+            for x in variant_desc.properties
+        )
+    )
+
+    new_requirements = []
+    for req in requirements:
+        parsed_req = Requirement(req)
+        marker = parsed_req.marker
+        # TODO: support more complex markers
+        if marker is None or len(marker._markers) != 1:  # noqa: SLF001
+            new_requirements.append(req)
+            continue
+
+        parsed_marker = marker._markers[0]  # noqa: SLF001
+        assert isinstance(parsed_marker[1], Op)
+        # "variants OP ..." is invalid
+        if (
+            isinstance(parsed_marker[0], Variable)
+            and str(parsed_marker[0]) == "variants"
+        ):
+            raise InvalidVariantEnvSpecError(
+                "'variants' marker can only be used in \"'foo' in variants\" "
+                "expressions"
+            )
+        # we are only interested in "... OP variants"
+        if not (
+            isinstance(parsed_marker[2], Variable)
+            and str(parsed_marker[2]) == "variants"
+        ):
+            new_requirements.append(req)
+            continue
+        # only "in" operator is allowed
+        if str(parsed_marker[1]) != "in" or not isinstance(parsed_marker[0], Value):
+            raise InvalidVariantEnvSpecError(
+                "'variants' marker can only be used in \"'foo' in variants\" "
+                "expressions"
+            )
+
+        if str(parsed_marker[0]) in all_values:
+            parsed_req.marker = None
+            new_requirements.append(str(parsed_req))
+
+    return new_requirements

--- a/variantlib/errors.py
+++ b/variantlib/errors.py
@@ -11,4 +11,4 @@ class PluginMissingError(RuntimeError):
 
 
 class InvalidVariantEnvSpecError(ValueError):
-    pass
+    """Environment specifier for variants is invalid"""

--- a/variantlib/errors.py
+++ b/variantlib/errors.py
@@ -4,3 +4,7 @@ class ValidationError(ValueError):
 
 class PluginError(RuntimeError):
     pass
+
+
+class InvalidVariantEnvSpecError(ValueError):
+    pass


### PR DESCRIPTION
Add an API to evaluate requirements with environment specifiers such as:

```toml
[build-system]
requires = [
        "variant-cuda; 'cuda :: runtime' in variants",
        "variant-x86-64; 'x86_64' in variants",
        "variant-cuda-extra; 'cuda' in variants and python_version >= '3.11'",
        "no-cuda; 'cuda' not in variants",
]
```

This is meant to be used in pypa/build tool. Currently, it just passes the whole `requires` key to pip/uv — but these tools don't know which variants are enabled. The idea is that build would know that, and preprocess the list, so that pip/uv would get only the dependencies they actually need.

My initial attempt (first commit) tried to use `packaging`, but there were two problems with that: almost entire environment marker API is private/internal, and we would have to implement boolean parser to evaluate compound statements correctly. So instead I went for a few regular expressions that should be reliable enough within the narrow scope of environment markers, and that replace the relevant markers with "always true" or "always false" expressions that pip/uv can handle.

Related: https://github.com/wheelnext/pep_xxx_wheel_variants/issues/15