### PR TITLE
Validator All Unique - Tune Up to make error explicit

### DIFF
--- a/variantlib/models/provider.py
+++ b/variantlib/models/provider.py
@@ -2,7 +2,6 @@ from __future__ import annotations
 
 from dataclasses import dataclass
 from dataclasses import field
-from operator import attrgetter
 
 from variantlib.constants import VALIDATION_FEATURE_REGEX
 from variantlib.constants import VALIDATION_NAMESPACE_REGEX
@@ -67,7 +66,7 @@ class ProviderConfig(BaseModel):
                 [
                     lambda v: validate_type(v, list[VariantFeatureConfig]),
                     lambda v: validate_list_min_len(v, 1),
-                    lambda v: validate_list_all_unique(v, key=attrgetter("name")),
+                    lambda v: validate_list_all_unique(v, keys=["name"]),
                 ],
                 value=val,
             ),

--- a/variantlib/models/validators.py
+++ b/variantlib/models/validators.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import logging
 import re
 from collections.abc import Iterable
+from operator import attrgetter
 from types import GenericAlias
 from typing import Any
 from typing import Callable
@@ -32,7 +33,7 @@ def validate_list_min_len(values: list, min_length: int) -> None:
         )
 
 
-def validate_list_all_unique(values: list[Any], key: None | Callable = None) -> None:
+def validate_list_all_unique(values: list[Any], keys: list[str] | None = None) -> None:
     """
     Validate that all elements in the list are unique.
     Raises a ValueError if duplicates are found.
@@ -40,13 +41,17 @@ def validate_list_all_unique(values: list[Any], key: None | Callable = None) -> 
     seen = set()
 
     for value in values:
-        if key is not None:
-            value = key(value)  # noqa: PLW2901
+        _value = value
 
-        if value in seen:
-            raise ValidationError(f"Duplicate value found: '{value}' in list.")
+        if keys is not None:
+            _value = tuple([attrgetter(key)(value) for key in keys])
+            if len(_value) == 1:
+                _value = _value[0]
 
-        seen.add(value)
+        if _value in seen:
+            raise ValidationError(f"Duplicate value found: '{_value}' in list.")
+
+        seen.add(_value)
 
 
 def validate_or(validators: list[Callable], value: Any) -> None:

--- a/variantlib/models/validators.py
+++ b/variantlib/models/validators.py
@@ -3,7 +3,6 @@ from __future__ import annotations
 import logging
 import re
 from collections.abc import Iterable
-from operator import attrgetter
 from types import GenericAlias
 from typing import Any
 from typing import Callable
@@ -44,7 +43,7 @@ def validate_list_all_unique(values: list[Any], keys: list[str] | None = None) -
         _value = value
 
         if keys is not None:
-            _value = tuple([attrgetter(key)(value) for key in keys])
+            _value = tuple([getattr(value, key) for key in keys])
             if len(_value) == 1:
                 _value = _value[0]
 

--- a/variantlib/models/variant.py
+++ b/variantlib/models/variant.py
@@ -7,7 +7,6 @@ import sys
 from dataclasses import asdict
 from dataclasses import dataclass
 from dataclasses import field
-from operator import attrgetter
 
 from variantlib.constants import VALIDATION_FEATURE_REGEX
 from variantlib.constants import VALIDATION_NAMESPACE_REGEX
@@ -165,7 +164,7 @@ class VariantDescription(BaseModel):
                     lambda v: validate_type(v, list[VariantProperty]),
                     lambda v: validate_list_min_len(v, 1),
                     lambda v: validate_list_all_unique(
-                        v, key=attrgetter("feature_hash")
+                        v, keys=["namespace", "feature"]
                     ),
                 ],
                 value=val,


### PR DESCRIPTION
This PR replaces the following:

```python
lambda v: validate_list_all_unique(
    v, key=attrgetter("feature_hash")
)
```

By the following:

```python
lambda v: validate_list_all_unique(
    v, keys=("namespace", "feature")
)
```

The new validator is preferable (though equivalent) to avoid a cryptic error message:
```bash
# Before
variantlib.errors.ValidationError: Duplicate value found: '7153903334020990830' in list.

# After
variantlib.errors.ValidationError: Duplicate value found: '('my_namespace', 'my_feature')' in list.
```