### PR TITLE
Make WHEEL_NAME_VALIDATION_REGEX verbose and improve it

### DIFF
--- a/variantlib/constants.py
+++ b/variantlib/constants.py
@@ -13,19 +13,22 @@ METADATA_VARIANT_HASH_HEADER = "Variant-hash"
 METADATA_VARIANT_PROPERTY_HEADER = "Variant"
 
 WHEEL_NAME_VALIDATION_REGEX = re.compile(
-    r"^                                       "
-    r"(?P<namever>                            "  # "namever" group contains <name>-<ver>
-    r"  (?P<name>[^\s-]+?) - (?P<ver>[^\s-]*?)"  # <name> "-" <ver>
-    r")                                       "  # close "namever" group
-    r"( - (?P<build>\d[^-]*?) )?              "  # optional "-" <build>
-    r"- (?P<pyver>[^\s-]+?)                   "  # "-" <pyver> tag
-    r"- (?P<abi>[^\s-]+?)                     "  # "-" <abi> tag
-    r"- (?P<plat>[^\s-]+?)                    "  # "-" <plat> tag
-    r"( - (?P<variant_hash>                   "  # optional <variant_hash>
-    rf"    [0-9a-f]{{{VARIANT_HASH_LEN}}}     "
-    r"    )                                   "
-    r")?                                      "
-    r"\.whl                                   "  # ".whl" suffix
-    r"$                                       ",
+    r"^                                   "
+    r"(?P<base_wheel_name>                "  # <base_wheel_name> group (without variant)
+    r"  (?P<namever>                      "  # "namever" group contains <name>-<ver>
+    r"    (?P<name>[^\s-]+?)              "  # <name>
+    r"    - (?P<ver>[^\s-]*?)             "  # "-" <ver>
+    r"  )                                 "  # close "namever" group
+    r"  ( - (?P<build>\d[^-]*?) )?        "  # optional "-" <build>
+    r"  - (?P<pyver>[^\s-]+?)             "  # "-" <pyver> tag
+    r"  - (?P<abi>[^\s-]+?)               "  # "-" <abi> tag
+    r"  - (?P<plat>[^\s-]+?)              "  # "-" <plat> tag
+    r")                                   "  # end of <base_wheel_name> group
+    r"( - (?P<variant_hash>               "  # optional <variant_hash>
+    rf"    [0-9a-f]{{{VARIANT_HASH_LEN}}} "
+    r"    )                               "
+    r")?                                  "
+    r"\.whl                               "  # ".whl" suffix
+    r"$                                   ",
     re.VERBOSE,
 )

--- a/variantlib/constants.py
+++ b/variantlib/constants.py
@@ -13,9 +13,19 @@ METADATA_VARIANT_HASH_HEADER = "Variant-hash"
 METADATA_VARIANT_PROPERTY_HEADER = "Variant"
 
 WHEEL_NAME_VALIDATION_REGEX = re.compile(
-    rf"""^(?P<namever>(?P<name>[^\s-]+?)-(?P<ver>[^\s-]*?))
-        ((-(?P<build>\d[^-]*?))?-(?P<pyver>[^\s-]+?)-(?P<abi>[^\s-]+?)-(?P<plat>[^\s-]+?)
-        (-(?P<variant_hash>[0-9a-f]{{{VARIANT_HASH_LEN}}}))?
-        \.whl|\.dist-info)$""",
+    r"^                                       "
+    r"(?P<namever>                            "  # "namever" group contains <name>-<ver>
+    r"  (?P<name>[^\s-]+?) - (?P<ver>[^\s-]*?)"  # <name> "-" <ver>
+    r")                                       "  # close "namever" group
+    r"( - (?P<build>\d[^-]*?) )?              "  # optional "-" <build>
+    r"- (?P<pyver>[^\s-]+?)                   "  # "-" <pyver> tag
+    r"- (?P<abi>[^\s-]+?)                     "  # "-" <abi> tag
+    r"- (?P<plat>[^\s-]+?)                    "  # "-" <plat> tag
+    r"( - (?P<variant_hash>                   "  # optional <variant_hash>
+    rf"    [0-9a-f]{{{VARIANT_HASH_LEN}}}     "
+    r"    )                                   "
+    r")?                                      "
+    r"\.whl                                   "  # ".whl" suffix
+    r"$                                       ",
     re.VERBOSE,
 )


### PR DESCRIPTION
1. Make the regex verbose to make it clear what it does.
2. Remove support for `.dist-info` files — we're using the regex on wheels only, so matching `.dist-info` files would give wrong results.
3. Add a convenience `base_wheel_name` group that I'll use in `make_variant` to easily construct filenames.