### PR TITLE
Add `Variant-provider` metadata

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,4 +1,4 @@
-exclude: "^docs/|/migrations/|devcontainer.json|.*.html|.*.css|.*.js|.*.svg|.*.dist"
+exclude: "^docs/|/migrations/|devcontainer[.]json$|.*[.]html$|.*[.]css$|.*[.]js$|.*[.]svg$|.*[.]dist$"
 
 default_language_version:
   python: python3.13

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -151,9 +151,9 @@ def test_set_variant_metadata(
         metadata,
         VariantDescription(
             [
-                VariantProperty("test_plugin", "name1", "val1d"),
-                VariantProperty("test_plugin", "name2", "val2a"),
-                VariantProperty("second_plugin", "name3", "val3a"),
+                VariantProperty("test_namespace", "name1", "val1d"),
+                VariantProperty("test_namespace", "name2", "val2a"),
+                VariantProperty("second_namespace", "name3", "val3a"),
             ]
         ),
     )
@@ -161,12 +161,12 @@ def test_set_variant_metadata(
         "Metadata-Version: 2.1\n"
         "Name: test-package\n"
         "Version: 1.2.3\n"
-        "Variant: second_plugin :: name3 :: val3a\n"
-        "Variant: test_plugin :: name1 :: val1d\n"
-        "Variant: test_plugin :: name2 :: val2a\n"
+        "Variant: second_namespace :: name3 :: val3a\n"
+        "Variant: test_namespace :: name1 :: val1d\n"
+        "Variant: test_namespace :: name2 :: val2a\n"
         "Variant-hash: 9c796125\n"
-        "Variant-provider: second_plugin, second-plugin\n"
-        "Variant-provider: test_plugin, test-plugin\n"
+        "Variant-provider: second_namespace, second-plugin\n"
+        "Variant-provider: test_namespace, test-plugin\n"
         "\n"
         "long description\n"
         "of a package\n"

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -92,14 +92,14 @@ def test_validate_variant(mocked_plugin_loader: type[PluginLoader]):  # noqa: F8
     res = validate_variant(
         VariantDescription(
             [
-                VariantProperty("test_plugin", "name1", "val1d"),
-                VariantProperty("test_plugin", "name2", "val2d"),
-                VariantProperty("test_plugin", "name3", "val3a"),
-                VariantProperty("second_plugin", "name3", "val3a"),
-                VariantProperty("incompatible_plugin", "flag1", "on"),
-                VariantProperty("incompatible_plugin", "flag2", "off"),
-                VariantProperty("incompatible_plugin", "flag5", "on"),
-                VariantProperty("missing_plugin", "name", "val"),
+                VariantProperty("test_namespace", "name1", "val1d"),
+                VariantProperty("test_namespace", "name2", "val2d"),
+                VariantProperty("test_namespace", "name3", "val3a"),
+                VariantProperty("second_namespace", "name3", "val3a"),
+                VariantProperty("incompatible_namespace", "flag1", "on"),
+                VariantProperty("incompatible_namespace", "flag2", "off"),
+                VariantProperty("incompatible_namespace", "flag5", "on"),
+                VariantProperty("missing_namespace", "name", "val"),
                 VariantProperty("private", "build_type", "debug"),
             ]
         )
@@ -107,14 +107,14 @@ def test_validate_variant(mocked_plugin_loader: type[PluginLoader]):  # noqa: F8
 
     assert res == VariantValidationResult(
         {
-            VariantProperty("test_plugin", "name1", "val1d"): True,
-            VariantProperty("test_plugin", "name2", "val2d"): False,
-            VariantProperty("test_plugin", "name3", "val3a"): False,
-            VariantProperty("second_plugin", "name3", "val3a"): True,
-            VariantProperty("incompatible_plugin", "flag1", "on"): True,
-            VariantProperty("incompatible_plugin", "flag2", "off"): False,
-            VariantProperty("incompatible_plugin", "flag5", "on"): False,
-            VariantProperty("missing_plugin", "name", "val"): None,
+            VariantProperty("test_namespace", "name1", "val1d"): True,
+            VariantProperty("test_namespace", "name2", "val2d"): False,
+            VariantProperty("test_namespace", "name3", "val3a"): False,
+            VariantProperty("second_namespace", "name3", "val3a"): True,
+            VariantProperty("incompatible_namespace", "flag1", "on"): True,
+            VariantProperty("incompatible_namespace", "flag2", "off"): False,
+            VariantProperty("incompatible_namespace", "flag5", "on"): False,
+            VariantProperty("missing_namespace", "name", "val"): None,
             VariantProperty("private", "build_type", "debug"): None,
         }
     )
@@ -164,7 +164,7 @@ def test_set_variant_metadata(
         "Variant: second_namespace :: name3 :: val3a\n"
         "Variant: test_namespace :: name1 :: val1d\n"
         "Variant: test_namespace :: name2 :: val2a\n"
-        "Variant-hash: 9c796125\n"
+        "Variant-hash: c105e82f\n"
         "Variant-provider: second_namespace, second-plugin\n"
         "Variant-provider: test_namespace, test-plugin\n"
         "\n"

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+from email.message import EmailMessage
 from string import ascii_lowercase
 from typing import TYPE_CHECKING
 
@@ -12,6 +13,7 @@ from variantlib.api import VariantFeatureConfig
 from variantlib.api import VariantProperty
 from variantlib.api import VariantValidationResult
 from variantlib.api import get_variant_hashes_by_priority
+from variantlib.api import set_variant_metadata
 from variantlib.api import validate_variant
 from variantlib.models import provider as pconfig
 from variantlib.models import variant as vconfig
@@ -117,3 +119,55 @@ def test_validate_variant(mocked_plugin_loader: type[PluginLoader]):  # noqa: F8
         }
     )
     assert not res.is_valid()
+
+
+@pytest.fixture
+def metadata() -> EmailMessage:
+    metadata = EmailMessage()
+    metadata.set_content("long description\nof a package")
+    # remove implicitly added Content-* headers to match Python metadata
+    for key in metadata:
+        del metadata[key]
+    metadata["Metadata-Version"] = "2.1"
+    metadata["Name"] = "test-package"
+    metadata["Version"] = "1.2.3"
+    return metadata
+
+
+@pytest.mark.parametrize("replace", [False, True])
+def test_set_variant_metadata(
+    mocked_plugin_loader: type[PluginLoader],  # noqa: F811
+    metadata: EmailMessage,
+    replace: bool,
+):
+    if replace:
+        # deliberately using different case
+        metadata["Variant-Hash"] = "12345678"
+        metadata["variant"] = "a :: b :: c"
+        metadata["variant"] = "d :: e :: f"
+        metadata["variant-Provider"] = "a, frobnicate"
+
+    set_variant_metadata(
+        metadata,
+        VariantDescription(
+            [
+                VariantProperty("test_plugin", "name1", "val1d"),
+                VariantProperty("test_plugin", "name2", "val2a"),
+                VariantProperty("second_plugin", "name3", "val3a"),
+            ]
+        ),
+    )
+    assert metadata.as_string() == (
+        "Metadata-Version: 2.1\n"
+        "Name: test-package\n"
+        "Version: 1.2.3\n"
+        "Variant: second_plugin :: name3 :: val3a\n"
+        "Variant: test_plugin :: name1 :: val1d\n"
+        "Variant: test_plugin :: name2 :: val2a\n"
+        "Variant-hash: 9c796125\n"
+        "Variant-provider: second_plugin, second-plugin\n"
+        "Variant-provider: test_plugin, test-plugin\n"
+        "\n"
+        "long description\n"
+        "of a package\n"
+    )

--- a/variantlib/commands/make_variant.py
+++ b/variantlib/commands/make_variant.py
@@ -14,14 +14,11 @@ from wheel.cli.unpack import unpack as wheel_unpack
 
 from variantlib.api import VariantDescription
 from variantlib.api import VariantProperty
+from variantlib.api import set_variant_metadata
 from variantlib.api import validate_variant
-from variantlib.constants import METADATA_VARIANT_HASH_HEADER
-from variantlib.constants import METADATA_VARIANT_PROPERTY_HEADER
-from variantlib.constants import METADATA_VARIANT_PROVIDER_HEADER
 from variantlib.constants import VARIANT_HASH_LEN
 from variantlib.constants import WHEEL_NAME_VALIDATION_REGEX
 from variantlib.errors import ValidationError
-from variantlib.loader import PluginLoader
 
 logger = logging.getLogger(__name__)
 logger.setLevel(logging.INFO)
@@ -188,10 +185,6 @@ def make_variant(args: list[str]) -> None:
             f"{', '.join(x.to_str() for x in vdesc_valid.unknown_properties)}"
         )
 
-    # Match namespaces to plugins
-    namespaces = {vprop.namespace for vprop in vdesc.properties}
-    providers = {ns: PluginLoader.distribution_names[ns] for ns in namespaces}
-
     with tempfile.TemporaryDirectory() as _tmpdir:
         tempdir = pathlib.Path(_tmpdir)
         wheel_unpack(input_filepath, tempdir)
@@ -213,19 +206,8 @@ def make_variant(args: list[str]) -> None:
             metadata_parser = email.parser.BytesParser()
             metadata = metadata_parser.parse(file)
 
-            # Remove old VariantProperties & Variant-Hash
-            del metadata[METADATA_VARIANT_PROPERTY_HEADER]
-            del metadata[METADATA_VARIANT_HASH_HEADER]
-            del metadata[METADATA_VARIANT_PROVIDER_HEADER]
-
-            # Add new VariantProperties & Variant-Hash
-            for vprop in vdesc.properties:
-                metadata[METADATA_VARIANT_PROPERTY_HEADER] = vprop.to_str()
-            metadata[METADATA_VARIANT_HASH_HEADER] = vdesc.hexdigest
-            for ns, provider in sorted(providers.items()):
-                # Follow the "<key>, <value>" format used in metadata already:
-                # https://packaging.python.org/en/latest/specifications/core-metadata/#project-url-multiple-use
-                metadata[METADATA_VARIANT_PROVIDER_HEADER] = f"{ns}, {provider}"
+            # Update the metadata
+            set_variant_metadata(metadata, vdesc)
 
             # Move the file pointer to the beginning
             file.seek(0)

--- a/variantlib/constants.py
+++ b/variantlib/constants.py
@@ -11,6 +11,7 @@ VALIDATION_VALUE_REGEX = r"^[A-Za-z0-9_.]+$"
 
 METADATA_VARIANT_HASH_HEADER = "Variant-hash"
 METADATA_VARIANT_PROPERTY_HEADER = "Variant"
+METADATA_VARIANT_PROVIDER_HEADER = "Variant-provider"
 
 WHEEL_NAME_VALIDATION_REGEX = re.compile(
     r"^                                   "


### PR DESCRIPTION
1. Add `Variant-provider` metadata key with dict of packages providing variant namespaces.
2. Add a common `variantlib.api.update_variant_metadata()` function to set variant-specific metadata wholesale in email-style dicts.
3. Use the new metadata in `generate_variants_json` to avoid requiring plugins being installed on index servers.

Also fixing excludes in pre-commit config, as they ignored `generate_variants_json.py` entirely.