### PR TITLE
Add more tests for `get_configuration_files()`

### DIFF
--- a/tests/test_configuration.py
+++ b/tests/test_configuration.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import sys
 from pathlib import Path
+from typing import TYPE_CHECKING
 
 import platformdirs
 import tomli_w
@@ -14,6 +15,9 @@ from variantlib.models.configuration import VariantConfiguration as Configuratio
 from variantlib.models.variant import VariantFeature
 from variantlib.models.variant import VariantProperty
 
+if TYPE_CHECKING:
+    import pytest
+
 
 def test_reset():
     VariantConfiguration._config = ConfigurationModel.default()  # noqa: SLF001
@@ -23,6 +27,7 @@ def test_reset():
 
 
 def test_get_configuration_files():
+    get_configuration_files.cache_clear()
     config_files = get_configuration_files()
     assert config_files[ConfigEnvironments.LOCAL] == Path.cwd() / CONFIG_FILENAME
     assert (
@@ -41,6 +46,39 @@ def test_get_configuration_files():
         == Path(platformdirs.site_config_dir("variantlib", appauthor=False))
         / CONFIG_FILENAME
     )
+
+
+def test_get_configuration_files_xdg(tmp_path: Path, monkeypatch: pytest.MonkeyPatch):
+    monkeypatch.chdir(tmp_path)
+    monkeypatch.setattr(sys, "prefix", "/virtual-env")
+    monkeypatch.setenv("XDG_CONFIG_DIRS", "/system-config:/second-config")
+    monkeypatch.setenv("XDG_CONFIG_HOME", "/config-home")
+
+    get_configuration_files.cache_clear()
+    assert get_configuration_files() == {
+        ConfigEnvironments.LOCAL: tmp_path / "variants.toml",
+        ConfigEnvironments.VIRTUALENV: Path("/virtual-env/variants.toml"),
+        ConfigEnvironments.USER: Path("/config-home/variantlib/variants.toml"),
+        ConfigEnvironments.GLOBAL: Path("/system-config/variantlib/variants.toml"),
+    }
+
+
+def test_get_configuration_files_unix(tmp_path: Path, monkeypatch: pytest.MonkeyPatch):
+    monkeypatch.chdir(tmp_path)
+    monkeypatch.setattr(sys, "prefix", "/virtual-env")
+    monkeypatch.setenv("HOME", "/home/mocked-user")
+    monkeypatch.delenv("XDG_CONFIG_DIRS")
+    monkeypatch.delenv("XDG_CONFIG_HOME")
+
+    get_configuration_files.cache_clear()
+    assert get_configuration_files() == {
+        ConfigEnvironments.LOCAL: tmp_path / "variants.toml",
+        ConfigEnvironments.VIRTUALENV: Path("/virtual-env/variants.toml"),
+        ConfigEnvironments.USER: Path(
+            "/home/mocked-user/.config/variantlib/variants.toml"
+        ),
+        ConfigEnvironments.GLOBAL: Path("/etc/xdg/variantlib/variants.toml"),
+    }
 
 
 def test_get_default_config_with_no_file(mocker):

--- a/tests/test_configuration.py
+++ b/tests/test_configuration.py
@@ -99,23 +99,6 @@ def test_get_configuration_files_macos(tmp_path: Path, monkeypatch: pytest.Monke
     }
 
 
-@pytest.mark.skipif(sys.platform != "win32", reason="Windows-specific")
-def test_get_configuration_files_win32(tmp_path: Path, monkeypatch: pytest.MonkeyPatch):
-    monkeypatch.chdir(tmp_path)
-    monkeypatch.setattr(sys, "prefix", "c:\\virtual-env")
-    monkeypatch.setenv("USERPROFILE", "c:\\users\\mocked-user")
-
-    get_configuration_files.cache_clear()
-    assert get_configuration_files() == {
-        ConfigEnvironments.LOCAL: tmp_path / "variants.toml",
-        ConfigEnvironments.VIRTUALENV: Path("c:/virtual-env/variants.toml"),
-        ConfigEnvironments.USER: Path(
-            "c:/users/mocked-user/AppData/Roaming/variantlib/variants.toml"
-        ),
-        ConfigEnvironments.GLOBAL: Path("c:/ProgramData/variantlib/variants.toml"),
-    }
-
-
 def test_get_default_config_with_no_file(mocker):
     mocker.patch("variantlib.configuration.get_configuration_files").return_value = {
         ConfigEnvironments.LOCAL: Path("/nonexistent/config.toml"),

--- a/tests/test_configuration.py
+++ b/tests/test_configuration.py
@@ -67,8 +67,8 @@ def test_get_configuration_files_unix(tmp_path: Path, monkeypatch: pytest.Monkey
     monkeypatch.chdir(tmp_path)
     monkeypatch.setattr(sys, "prefix", "/virtual-env")
     monkeypatch.setenv("HOME", "/home/mocked-user")
-    monkeypatch.delenv("XDG_CONFIG_DIRS")
-    monkeypatch.delenv("XDG_CONFIG_HOME")
+    monkeypatch.delenv("XDG_CONFIG_DIRS", raising=False)
+    monkeypatch.delenv("XDG_CONFIG_HOME", raising=False)
 
     get_configuration_files.cache_clear()
     assert get_configuration_files() == {

--- a/tests/test_configuration.py
+++ b/tests/test_configuration.py
@@ -2,9 +2,9 @@ from __future__ import annotations
 
 import sys
 from pathlib import Path
-from typing import TYPE_CHECKING
 
 import platformdirs
+import pytest
 import tomli_w
 
 from variantlib.configuration import ConfigEnvironments
@@ -14,9 +14,6 @@ from variantlib.constants import CONFIG_FILENAME
 from variantlib.models.configuration import VariantConfiguration as ConfigurationModel
 from variantlib.models.variant import VariantFeature
 from variantlib.models.variant import VariantProperty
-
-if TYPE_CHECKING:
-    import pytest
 
 
 def test_reset():
@@ -48,6 +45,7 @@ def test_get_configuration_files():
     )
 
 
+@pytest.mark.skipif(sys.platform in ("darwin", "win32"))
 def test_get_configuration_files_xdg(tmp_path: Path, monkeypatch: pytest.MonkeyPatch):
     monkeypatch.chdir(tmp_path)
     monkeypatch.setattr(sys, "prefix", "/virtual-env")
@@ -63,6 +61,7 @@ def test_get_configuration_files_xdg(tmp_path: Path, monkeypatch: pytest.MonkeyP
     }
 
 
+@pytest.mark.skipif(sys.platform in ("darwin", "win32"))
 def test_get_configuration_files_unix(tmp_path: Path, monkeypatch: pytest.MonkeyPatch):
     monkeypatch.chdir(tmp_path)
     monkeypatch.setattr(sys, "prefix", "/virtual-env")

--- a/variantlib/configuration.py
+++ b/variantlib/configuration.py
@@ -46,15 +46,11 @@ def get_configuration_files() -> dict[ConfigEnvironments, Path]:
         ConfigEnvironments.LOCAL: Path.cwd() / CONFIG_FILENAME,
         ConfigEnvironments.VIRTUALENV: Path(sys.prefix) / CONFIG_FILENAME,
         ConfigEnvironments.USER: (
-            Path(
-                platformdirs.user_config_dir(
-                    "variantlib", appauthor=False, roaming=True
-                )
-            )
+            platformdirs.user_config_path("variantlib", appauthor=False, roaming=True)
             / CONFIG_FILENAME
         ),
         ConfigEnvironments.GLOBAL: (
-            Path(platformdirs.site_config_dir("variantlib", appauthor=False))
+            platformdirs.site_config_path("variantlib", appauthor=False)
             / CONFIG_FILENAME
         ),
     }


### PR DESCRIPTION
Add Unix and macOS-specific tests for stability of paths returned by `get_configuration_files()`, and switch to platformdirs' `Path` methods instead of converting the strings to `Path`s manually.