### PR TITLE
Make importlib.metadata version lookup optional

### DIFF
--- a/variantlib/__init__.py
+++ b/variantlib/__init__.py
@@ -4,4 +4,7 @@ import importlib.metadata
 
 from variantlib import logger  # noqa: F401
 
-__version__ = importlib.metadata.version("variantlib")
+try:
+    __version__ = importlib.metadata.version("variantlib")
+except importlib.metadata.PackageNotFoundError:
+    __version__ = "unknown"


### PR DESCRIPTION
Handle failure to look version up from metadata gracefully.  We are using it only for commands, and it may be missing e.g. when we are vendored inside pip.