### PR TITLE
Add newlines to variant hash data to ensure uniqueness

### DIFF
--- a/tests/artifacts/variants.json
+++ b/tests/artifacts/variants.json
@@ -4,7 +4,7 @@
         "provider_fictional_tech"
     ],
     "variants": {
-        "a99ec74f": {
+        "9cc137a9": {
             "fictional_hw": {
                 "architecture": "HAL9000",
                 "compute_accuracy": "0",
@@ -12,7 +12,7 @@
                 "humor": "2"
             }
         },
-        "e0ae4d03": {
+        "80fa16ff": {
             "fictional_hw": {
                 "architecture": "tars",
                 "compute_accuracy": "8",
@@ -20,14 +20,14 @@
                 "humor": "10"
             }
         },
-        "f64f24af": {
+        "df159646": {
             "fictional_tech": {
                 "quantum": "FOAM",
                 "risk_exposure": "1000000000",
                 "technology": "improb_drive"
             }
         },
-        "f371a05c": {
+        "4513a073": {
             "fictional_hw": {
                 "architecture": "deepthought",
                 "compute_accuracy": "10",
@@ -38,14 +38,14 @@
                 "quantum": "FOAM"
             }
         },
-        "316cf1c5": {
+        "2c4ac281": {
             "fictional_tech": {
                 "quantum": "SUPERPOSITION",
                 "risk_exposure": "25",
                 "technology": "auto_chef"
             }
         },
-        "d109b4f7": {
+        "03e04d5e": {
             "fictional_hw": {
                 "architecture": "mother",
                 "compute_capability": "4"

--- a/tests/models/test_variant.py
+++ b/tests/models/test_variant.py
@@ -305,12 +305,30 @@ def test_variantdescription_hexdigest():
     vdesc = VariantDescription(vprops)
 
     # Compute the expected hash using shake_128 (mock the hash output for testing)
-    hash_object = hashlib.sha256()
-    for vprop in vprops:
-        hash_object.update(vprop.to_str().encode("utf-8"))
+    hash_object = hashlib.sha256(
+        b"OmniCorp :: custom_feat :: secret_value\n"
+        b"TyrellCorporation :: client_id :: secret_pass\n"
+    )
     expected_hexdigest = hash_object.hexdigest()[:VARIANT_HASH_LEN]
 
     assert vdesc.hexdigest == expected_hexdigest
+
+
+def test_variantdescription_hexdigest_adjacent_strings():
+    assert (
+        VariantDescription(
+            [
+                VariantProperty("a", "b", "cx"),
+                VariantProperty("d", "e", "f"),
+            ]
+        ).hexdigest
+        != VariantDescription(
+            [
+                VariantProperty("a", "b", "c"),
+                VariantProperty("xd", "e", "f"),
+            ]
+        ).hexdigest
+    )
 
 
 def test_variantdescription_serialization():
@@ -341,7 +359,7 @@ def test_variantdescription_deserialization():
     assert vdesc.properties[0].namespace == "provider"
     assert vdesc.properties[0].feature == "feature"
     assert vdesc.properties[0].value == "value"
-    assert vdesc.hexdigest == "e4be6b4d"
+    assert vdesc.hexdigest == "c44d3adf"
 
 
 # -----------------------------------------------

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -273,7 +273,7 @@ def test_set_variant_metadata(
         "Variant: second_namespace :: name3 :: val3a\n"
         "Variant: test_namespace :: name1 :: val1d\n"
         "Variant: test_namespace :: name2 :: val2a\n"
-        "Variant-hash: ece1285e\n"
+        "Variant-hash: c9267e19\n"
         "Variant-provider: second_namespace, second-plugin\n"
         "Variant-provider: test_namespace, test-plugin\n"
         "\n"

--- a/variantlib/models/variant.py
+++ b/variantlib/models/variant.py
@@ -201,7 +201,7 @@ class VariantDescription(BaseModel):
         """
         hash_object = hashlib.sha256()
         for vprop in self.properties:
-            hash_object.update(vprop.to_str().encode("utf-8"))
+            hash_object.update(f"{vprop.to_str()}\n".encode())
 
         # Like digest() except the digest is returned as a string object of double
         # length, containing only hexadecimal digits. This may be used to exchange the

--- a/variantlib/models/variant.py
+++ b/variantlib/models/variant.py
@@ -200,6 +200,15 @@ class VariantDescription(BaseModel):
         Compute the hash of the object.
         """
         hash_object = hashlib.sha256()
+        # Append a newline to every serialized property to ensure that they
+        # are separated from one another. Otherwise, two "adjacent" variants
+        # such as:
+        #     a :: b :: cx
+        #     d :: e :: f
+        # and:
+        #     a :: b :: c
+        #     xd :: e :: f
+        # would serialize to the same hash.
         for vprop in self.properties:
             hash_object.update(f"{vprop.to_str()}\n".encode())
 


### PR DESCRIPTION
Add newlines to variant property strings when computing the variant hash in order to ensure that different sets of variant properties always result in different hashes.

For example, previously the variant:

    a :: b :: cx
    d :: e :: f

would result in the same hash as:

    a :: b :: c
    xd :: e :: f

Appending a newline to every entry seems the most logical solution, as it effectively means that variant properties are serialized into a text-friendly, newline-separated list of strings.