### PR TITLE
[Feature] Null Variant Support

### DIFF
--- a/tests/models/test_variant.py
+++ b/tests/models/test_variant.py
@@ -221,6 +221,12 @@ def test_variantprop_sorting():
 # -----------------------------------------------
 
 
+def test_null_variant():
+    vdesc = VariantDescription()
+    assert vdesc.properties == []
+    assert vdesc.hexdigest == "00000000"
+
+
 def test_variantdescription_initialization():
     # Valid input: List of VariantProperty instances
     vprop1 = VariantProperty(

--- a/tests/resolver/test_lib.py
+++ b/tests/resolver/test_lib.py
@@ -185,6 +185,7 @@ def test_filter_variants_only_one_prop_allowed(
     assert len(vprops) == 6
     _, _, _, vprop4, _, _ = vprops
 
+    # Shuffling the list & creating duplicates
     inputs_vdescs = shuffle_vdescs_with_duplicates(vdescs=vdescs)
 
     assert (
@@ -244,6 +245,7 @@ def test_filter_variants_forbidden_feature_allowed_prop(
     assert len(vprops) == 6
     _, vprop2, _, vprop4, _, _ = vprops
 
+    # Shuffling the list & creating duplicates
     inputs_vdescs = shuffle_vdescs_with_duplicates(vdescs=vdescs)
 
     assert list(
@@ -261,6 +263,7 @@ def test_filter_variants_forbidden_namespace_allowed_prop(
     assert len(vprops) == 6
     vprop1, _, _, vprop4, _, _ = vprops
 
+    # Shuffling the list & creating duplicates
     inputs_vdescs = shuffle_vdescs_with_duplicates(vdescs=vdescs)
 
     assert list(
@@ -285,6 +288,7 @@ def test_filter_variants_only_remove_duplicates(
 ):
     assert len(vprops) == 6
 
+    # Shuffling the list & creating duplicates
     inputs_vdescs = shuffle_vdescs_with_duplicates(vdescs=vdescs)
 
     ddiff = deep_diff(
@@ -306,6 +310,8 @@ def test_filter_variants_remove_duplicates_and_namespaces(
     assert len(vprops) == 6
     _, _, vprop3, vprop4, vprop5, vprop6 = vprops
 
+    # Adding the `null-Variant` and shuffling the list & creating duplicates
+    vdescs = [*vdescs, VariantDescription()]
     inputs_vdescs = shuffle_vdescs_with_duplicates(vdescs=vdescs)
 
     expected_vdescs = [
@@ -326,6 +332,8 @@ def test_filter_variants_remove_duplicates_and_namespaces(
         VariantDescription([vprop4]),
         VariantDescription([vprop5]),
         VariantDescription([vprop6]),
+        # Null-Variant is never removed and last
+        VariantDescription(),
     ]
 
     ddiff = deep_diff(
@@ -360,6 +368,8 @@ def test_filter_variants_remove_duplicates_and_features(
     assert len(vprops) == 6
     vprop1, vprop2, vprop3, vprop4, vprop5, vprop6 = vprops
 
+    # Adding the `null-Variant` and shuffling the list & creating duplicates
+    vdescs = [*vdescs, VariantDescription()]
     inputs_vdescs = shuffle_vdescs_with_duplicates(vdescs=vdescs)
 
     expected_vdescs = [
@@ -371,6 +381,8 @@ def test_filter_variants_remove_duplicates_and_features(
         VariantDescription([vprop1]),
         VariantDescription([vprop4]),
         VariantDescription([vprop5]),
+        # Null-Variant is never removed and last
+        VariantDescription(),
     ]
 
     forbidden_features = [
@@ -411,6 +423,8 @@ def test_filter_variants_remove_duplicates_and_properties(
     assert len(vprops) == 6
     vprop1, vprop2, _, vprop4, vprop5, _ = vprops
 
+    # Adding the `null-Variant` and shuffling the list & creating duplicates
+    vdescs = [*vdescs, VariantDescription()]
     inputs_vdescs = shuffle_vdescs_with_duplicates(vdescs=vdescs)
 
     expected_vdescs = [
@@ -422,6 +436,8 @@ def test_filter_variants_remove_duplicates_and_properties(
         VariantDescription([vprop1]),
         VariantDescription([vprop4]),
         VariantDescription([vprop5]),
+        # Null-Variant is never removed and last
+        VariantDescription(),
     ]
 
     allowed_properties = [vprop1, vprop2, vprop4, vprop5]
@@ -522,9 +538,13 @@ def test_sort_and_filter_supported_variants(
         VariantDescription([vprop1, vprop6]),
         VariantDescription([vprop6]),
         VariantDescription([vprop1]),
+
+        # Null-Variant is never removed and last - Implicitly added
+        VariantDescription(),
     ]
     # fmt: on
 
+    # Shuffling the list & creating duplicates
     inputs_vdescs = shuffle_vdescs_with_duplicates(vdescs=vdescs)
 
     ddiff = deep_diff(

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -54,9 +54,11 @@ def test_get_variant_hashes_by_priority_roundtrip(mocker, configs):
 
     namespace_priorities = ["test_namespace", "second_namespace"]
 
-    combinations: list[VariantDescription] = list(
-        get_combinations(configs, namespace_priorities)
-    )
+    # The null-variant is always the last one and implicitly added
+    combinations: list[VariantDescription] = [
+        *list(get_combinations(configs, namespace_priorities)),
+        VariantDescription(),
+    ]
     variants_json = {
         VARIANTS_JSON_VARIANT_DATA_KEY: {
             vdesc.hexdigest: vdesc.to_dict() for vdesc in combinations
@@ -127,7 +129,12 @@ def test_get_variant_hashes_by_priority_roundtrip_fuzz(mocker, configs):
             assume(i < 65536)
             yield x
 
-    combinations: list[VariantDescription] = list(get_or_skip_combinations())
+    # The null-variant is always the last one and implicitly added
+    combinations: list[VariantDescription] = [
+        *list(get_or_skip_combinations()),
+        VariantDescription(),
+    ]
+
     variants_json = {
         VARIANTS_JSON_VARIANT_DATA_KEY: {
             vdesc.hexdigest: vdesc.to_dict() for vdesc in combinations

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -57,7 +57,6 @@ def test_get_variant_hashes_by_priority_roundtrip(mocker, configs):
     # The null-variant is always the last one and implicitly added
     combinations: list[VariantDescription] = [
         *list(get_combinations(configs, namespace_priorities)),
-        VariantDescription(),
     ]
     variants_json = {
         VARIANTS_JSON_VARIANT_DATA_KEY: {
@@ -130,10 +129,7 @@ def test_get_variant_hashes_by_priority_roundtrip_fuzz(mocker, configs):
             yield x
 
     # The null-variant is always the last one and implicitly added
-    combinations: list[VariantDescription] = [
-        *list(get_or_skip_combinations()),
-        VariantDescription(),
-    ]
+    combinations: list[VariantDescription] = [*list(get_or_skip_combinations())]
 
     variants_json = {
         VARIANTS_JSON_VARIANT_DATA_KEY: {

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -57,6 +57,7 @@ def test_get_combinations(configs):
         VariantDescription([val2c, val3a]),
         VariantDescription([val2c]),
         VariantDescription([val3a]),
+        VariantDescription(),
     ]
 
 
@@ -98,6 +99,7 @@ def test_get_combinations_flipped_order(configs):
         VariantDescription([val2a]),
         VariantDescription([val2b]),
         VariantDescription([val2c]),
+        VariantDescription(),
     ]
 
 
@@ -107,7 +109,12 @@ def test_get_combinations_one_one_namespace_one(configs):
     namespace_priorities = ["second_namespace"]
 
     assert list(get_combinations(configs, namespace_priorities)) == [
-        VariantDescription([VariantProperty("second_namespace", "name3", "val3a")]),
+        VariantDescription(
+            [
+                VariantProperty("second_namespace", "name3", "val3a"),
+            ]
+        ),
+        VariantDescription(),
     ]
 
 
@@ -135,6 +142,7 @@ def test_get_combinations_one_one_namespace_two(configs):
         VariantDescription([val2a]),
         VariantDescription([val2b]),
         VariantDescription([val2c]),
+        VariantDescription(),
     ]
 
 

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -50,3 +50,6 @@ def get_combinations(
     for start in range(len(all_properties)):
         for properties in yield_all_values(all_properties[start:]):
             yield VariantDescription(properties)
+
+    # Finish by the null variant
+    yield VariantDescription()

--- a/variantlib/commands/generate_index_json.py
+++ b/variantlib/commands/generate_index_json.py
@@ -13,6 +13,7 @@ from collections import defaultdict
 from variantlib.constants import METADATA_VARIANT_PROPERTY_HEADER
 from variantlib.constants import METADATA_VARIANT_PROVIDER_HEADER
 from variantlib.constants import VALIDATION_WHEEL_NAME_REGEX
+from variantlib.constants import VARIANT_HASH_LEN
 from variantlib.constants import VARIANTS_JSON_PROVIDER_DATA_KEY
 from variantlib.constants import VARIANTS_JSON_VARIANT_DATA_KEY
 from variantlib.errors import ValidationError
@@ -59,11 +60,15 @@ def generate_index_json(args: list[str]) -> None:
             )
             continue
 
-        if wheel_info.group("variant_hash") is None:
+        if (vhash := wheel_info.group("variant_hash")) is None:
             logger.debug(
-                "Filepath: `%(input_file)s` ... is not a wheel variant.",
+                "Filepath: `%(input_file)s` ... is not a wheel variant. Skipping ...",
                 {"input_file": wheel.name},
             )
+            continue
+
+        if vhash == "0" * VARIANT_HASH_LEN:
+            known_variants[vhash] = VariantDescription()
             continue
 
         with zipfile.ZipFile(wheel, "r") as zip_file:

--- a/variantlib/commands/generate_index_json.py
+++ b/variantlib/commands/generate_index_json.py
@@ -13,7 +13,6 @@ from collections import defaultdict
 from variantlib.constants import METADATA_VARIANT_PROPERTY_HEADER
 from variantlib.constants import METADATA_VARIANT_PROVIDER_HEADER
 from variantlib.constants import VALIDATION_WHEEL_NAME_REGEX
-from variantlib.constants import VARIANT_HASH_LEN
 from variantlib.constants import VARIANTS_JSON_PROVIDER_DATA_KEY
 from variantlib.constants import VARIANTS_JSON_VARIANT_DATA_KEY
 from variantlib.errors import ValidationError
@@ -67,9 +66,9 @@ def generate_index_json(args: list[str]) -> None:
             )
             continue
 
-        if vhash == "0" * VARIANT_HASH_LEN:
-            known_variants[vhash] = VariantDescription()
-            continue
+        # if vhash == "0" * VARIANT_HASH_LEN:
+        #     known_variants[vhash] = VariantDescription()
+        #     continue
 
         with zipfile.ZipFile(wheel, "r") as zip_file:
             # Find the METADATA file
@@ -84,21 +83,16 @@ def generate_index_json(args: list[str]) -> None:
                 continue
 
             # Only valid Wheel Variants need to be processed
-            if (
-                variant_entries := wheel_metadata.get_all(
-                    METADATA_VARIANT_PROPERTY_HEADER
-                )
-            ) is None:
-                logger.warning(
-                    "%(wheel)s: This wheel does not declare any `%(key)s`",
-                    {"wheel": wheel, "key": METADATA_VARIANT_PROPERTY_HEADER},
-                )
-                continue
+            variant_properties = wheel_metadata.get_all(
+                METADATA_VARIANT_PROPERTY_HEADER, []
+            )
 
             # ============== Variant Properties Processing ================ #
 
             try:
-                vprops = [VariantProperty.from_str(vprop) for vprop in variant_entries]
+                vprops = [
+                    VariantProperty.from_str(vprop) for vprop in variant_properties
+                ]
                 vdesc = VariantDescription(vprops)
             except ValidationError:
                 logger.exception(
@@ -112,7 +106,7 @@ def generate_index_json(args: list[str]) -> None:
                 known_variants[vhash] = vdesc
 
             # ============== Variant Providers Processing ================ #
-            if not (
+            if variant_properties and not (
                 wheel_providers := wheel_metadata.get_all(
                     METADATA_VARIANT_PROVIDER_HEADER, []
                 )

--- a/variantlib/models/variant.py
+++ b/variantlib/models/variant.py
@@ -206,7 +206,7 @@ class VariantDescription(BaseModel):
         """
         Compute the hash of the object.
         """
-        if not self.properties:
+        if self.is_null_variant:
             # The `null-variant` is a special case where no properties are defined.
             return "0" * VARIANT_HASH_LEN
 

--- a/variantlib/models/variant.py
+++ b/variantlib/models/variant.py
@@ -193,7 +193,6 @@ class VariantDescription(BaseModel):
         # Execute the validator
         super().__post_init__()
 
-    @property
     def is_null_variant(self) -> bool:
         """
         Check if the variant is a null variant.
@@ -206,7 +205,7 @@ class VariantDescription(BaseModel):
         """
         Compute the hash of the object.
         """
-        if self.is_null_variant:
+        if self.is_null_variant():
             # The `null-variant` is a special case where no properties are defined.
             return "0" * VARIANT_HASH_LEN
 

--- a/variantlib/models/variant.py
+++ b/variantlib/models/variant.py
@@ -199,7 +199,7 @@ class VariantDescription(BaseModel):
         Check if the variant is a null variant.
         A null variant is a variant with no properties.
         """
-        return self.hexdigest == "0" * VARIANT_HASH_LEN
+        return not self.properties
 
     @cached_property
     def hexdigest(self) -> str:

--- a/variantlib/models/variant.py
+++ b/variantlib/models/variant.py
@@ -18,7 +18,6 @@ from variantlib.errors import ValidationError
 from variantlib.models.base import BaseModel
 from variantlib.validators import validate_and
 from variantlib.validators import validate_list_all_unique
-from variantlib.validators import validate_list_min_len
 from variantlib.validators import validate_matches_re
 from variantlib.validators import validate_type
 
@@ -172,14 +171,14 @@ class VariantDescription(BaseModel):
             "validator": lambda val: validate_and(
                 [
                     lambda v: validate_type(v, list[VariantProperty]),
-                    lambda v: validate_list_min_len(v, 1),
                     lambda v: validate_list_all_unique(
                         v, keys=["namespace", "feature"]
                     ),
                 ],
                 value=val,
             ),
-        }
+        },
+        default_factory=list,
     )
 
     def __post_init__(self) -> None:
@@ -194,11 +193,23 @@ class VariantDescription(BaseModel):
         # Execute the validator
         super().__post_init__()
 
+    @property
+    def is_null_variant(self) -> bool:
+        """
+        Check if the variant is a null variant.
+        A null variant is a variant with no properties.
+        """
+        return self.hexdigest == "0" * VARIANT_HASH_LEN
+
     @cached_property
     def hexdigest(self) -> str:
         """
         Compute the hash of the object.
         """
+        if not self.properties:
+            # The `null-variant` is a special case where no properties are defined.
+            return "0" * VARIANT_HASH_LEN
+
         hash_object = hashlib.sha256()
         # Append a newline to every serialized property to ensure that they
         # are separated from one another. Otherwise, two "adjacent" variants
@@ -249,13 +260,6 @@ class VariantDescription(BaseModel):
         ]
 
         return cls(vprops)
-
-    def pretty_print(self) -> str:
-        result_str = f"{'#' * 30} Variant: `{self.hexdigest}` {'#' * 29}"
-        for vprop in self.properties:
-            result_str += f"\nVariant Property: {vprop.to_str()}"
-        result_str += f"\n{'#' * 80}\n"
-        return result_str
 
 
 @dataclass(frozen=True)

--- a/variantlib/resolver/lib.py
+++ b/variantlib/resolver/lib.py
@@ -119,6 +119,8 @@ def sort_and_filter_supported_variants(
     """
     validate_type(vdescs, list[VariantDescription])
 
+    vdescs = [*vdescs, VariantDescription()]
+
     if supported_vprops is None:
         """No supported properties provided, return no variants."""
         return []

--- a/variantlib/resolver/sorting.py
+++ b/variantlib/resolver/sorting.py
@@ -173,7 +173,7 @@ def sort_variants_descriptions(
         :return: Rank tuple[int, ...] of the `VariantDescription` object.
         """
 
-        if vdesc.is_null_variant:
+        if vdesc.is_null_variant():
             # return the tuple that represents the lowest priority
             return tuple(sys.maxsize for _ in property_hash_priorities)
 

--- a/variantlib/resolver/sorting.py
+++ b/variantlib/resolver/sorting.py
@@ -173,6 +173,10 @@ def sort_variants_descriptions(
         :return: Rank tuple[int, ...] of the `VariantDescription` object.
         """
 
+        if vdesc.is_null_variant:
+            # return the tuple that represents the lowest priority
+            return tuple(sys.maxsize for _ in property_hash_priorities)
+
         # --------------------------- Implementation Notes --------------------------- #
         # - `property_hash_priorities` is ordered. It's a list.
         # - `vdesc_prop_hashes` is unordered. It's a set.

--- a/variantlib/validators.py
+++ b/variantlib/validators.py
@@ -197,6 +197,12 @@ def validate_variants_json(data: dict) -> None:
                 )
             continue
 
+        if len(vdata) == 0:
+            raise ValidationError(
+                f"Invalid variant data for non-null variant `{variant_hash}`: "
+                f"{vdata}. Should not be empty."
+            )
+
         # Check the Variant Data
         if not isinstance(vdata, dict):
             raise ValidationError(

--- a/variantlib/validators.py
+++ b/variantlib/validators.py
@@ -15,6 +15,7 @@ from variantlib.constants import VALIDATION_FEATURE_REGEX
 from variantlib.constants import VALIDATION_NAMESPACE_REGEX
 from variantlib.constants import VALIDATION_VALUE_REGEX
 from variantlib.constants import VALIDATION_VARIANT_HASH_REGEX
+from variantlib.constants import VARIANT_HASH_LEN
 from variantlib.constants import VARIANTS_JSON_VARIANT_DATA_KEY
 from variantlib.errors import ValidationError
 
@@ -184,8 +185,17 @@ def validate_variants_json(data: dict) -> None:
             raise ValidationError(
                 f"Invalid `variant_hash` type: `{variant_hash}` in data (expected str)"
             )
+
         if VALIDATION_VARIANT_HASH_REGEX.fullmatch(variant_hash) is None:
             raise ValidationError(f"Invalid variant hash `{variant_hash}` in data")
+
+        if variant_hash == "0" * VARIANT_HASH_LEN:
+            if len(vdata) != 0:
+                raise ValidationError(
+                    f"Invalid variant data for null variant `{variant_hash}`: "
+                    f"{vdata}. Should be empty."
+                )
+            continue
 
         # Check the Variant Data
         if not isinstance(vdata, dict):


### PR DESCRIPTION
This PR introduces the spec [tentatively] of `null-variant`. A variant with no variant-properties.
It has systematically the hash `000000000`.

This `null-variant` should be seen as the `default variant` no matter what hardware/software/drivers/etc. is installed.
However being a variant - it's only visible to people with `variant-enabled` installer.

This can be used to:
- Track what's the percentage of users still using the `non-variant` build
- Give a different "fallback" to users depending if their `installer` is `variant enabled` or not.
- The null variant is always added at the end by the resolver as a last resort "fallback"