### PR TITLE
Configure logger in CLI rather than in top-level package

### DIFF
--- a/variantlib/__init__.py
+++ b/variantlib/__init__.py
@@ -1,7 +1,6 @@
 from __future__ import annotations
 
 import importlib.metadata
-import logging
 
 __package_name__ = "variantlib"
 
@@ -9,10 +8,3 @@ try:
     __version__ = importlib.metadata.version(__package_name__)
 except importlib.metadata.PackageNotFoundError:
     __version__ = "unknown"
-
-logger = logging.getLogger(__package_name__)
-handler = logging.StreamHandler()
-formatter = logging.Formatter("%(name)s - %(levelname)s - %(message)s")
-handler.setFormatter(formatter)
-logger.addHandler(handler)
-logger.setLevel(logging.INFO)

--- a/variantlib/commands/main.py
+++ b/variantlib/commands/main.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import argparse
+import logging
 import sys
 
 import variantlib
@@ -15,6 +16,13 @@ else:
 
 
 def main() -> None:
+    logger = logging.getLogger(__package_name__)
+    handler = logging.StreamHandler()
+    formatter = logging.Formatter("%(name)s - %(levelname)s - %(message)s")
+    handler.setFormatter(formatter)
+    logger.addHandler(handler)
+    logger.setLevel(logging.INFO)
+
     registered_commands = entry_points(group=f"{__package_name__}.actions")
 
     parser = argparse.ArgumentParser(prog=__package_name__)


### PR DESCRIPTION
Instead of configuring the logger in top-level `variantlib` package, do it in the `main()` function of CLI.  This ensures that the library users will be able to configure logging as they see fit, while our defaults apply only to our own usage.