### PR TITLE
Unify command hyphenation and fix `prog_name`s

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -58,12 +58,12 @@ test = [
 variantlib = "variantlib.commands.main:main"
 
 [project.entry-points."variantlib.actions"]
-analyze_wheel = "variantlib.commands.analyze_wheel:analyze_wheel"
-analyze_platform = "variantlib.commands.analyze_platform:analyze_platform"
+analyze-wheel = "variantlib.commands.analyze_wheel:analyze_wheel"
+analyze-platform = "variantlib.commands.analyze_platform:analyze_platform"
 config = "variantlib.commands.config.main:main"
-generate_index_json = "variantlib.commands.generate_index_json:generate_index_json"
-make_variant = "variantlib.commands.make_variant:make_variant"
-unmake_variant = "variantlib.commands.unmake_variant:unmake_variant"
+generate-index-json = "variantlib.commands.generate_index_json:generate_index_json"
+make-variant = "variantlib.commands.make_variant:make_variant"
+unmake-variant = "variantlib.commands.unmake_variant:unmake_variant"
 plugins = "variantlib.commands.plugins.main:main"
 
 [project.entry-points."variantlib.actions.config"]

--- a/variantlib/commands/analyze_platform.py
+++ b/variantlib/commands/analyze_platform.py
@@ -4,6 +4,7 @@ import argparse
 import logging
 import sys
 
+from variantlib import __package_name__
 from variantlib.loader import PluginLoader
 
 logger = logging.getLogger(__name__)
@@ -11,7 +12,7 @@ logger = logging.getLogger(__name__)
 
 def analyze_platform(args: list[str]) -> None:
     parser = argparse.ArgumentParser(
-        prog="analyze_platform",
+        prog=f"{__package_name__} analyze-platform",
         description="Analyze the platform and return the variant hashes compatible",
     )
     _ = parser.parse_args(args)

--- a/variantlib/commands/analyze_wheel.py
+++ b/variantlib/commands/analyze_wheel.py
@@ -7,6 +7,7 @@ import re
 import sys
 import zipfile
 
+from variantlib import __package_name__
 from variantlib.constants import METADATA_VARIANT_HASH_HEADER
 from variantlib.constants import METADATA_VARIANT_PROPERTY_HEADER
 from variantlib.constants import METADATA_VARIANT_PROVIDER_HEADER
@@ -30,7 +31,8 @@ def pretty_print(vdesc: VariantDescription, providers: list[ProviderPackage]) ->
 
 def analyze_wheel(args: list[str]) -> None:
     parser = argparse.ArgumentParser(
-        prog="analyze_wheel", description="Analyze a Wheel file for Variant Information"
+        prog=f"{__package_name__} analyze-wheel",
+        description="Analyze a Wheel file for Variant Information",
     )
     parser.add_argument(
         "-i",

--- a/variantlib/commands/config/list_paths.py
+++ b/variantlib/commands/config/list_paths.py
@@ -5,6 +5,7 @@ import logging
 import sys
 from datetime import datetime
 
+from variantlib import __package_name__
 from variantlib.configuration import get_configuration_files
 
 try:
@@ -20,7 +21,7 @@ logger = logging.getLogger(__name__)
 
 def list_paths(args: list[str]) -> None:
     parser = argparse.ArgumentParser(
-        prog="list-paths",
+        prog=f"{__package_name__} config list-paths",
         description="CLI interface to list configuration paths",
     )
 

--- a/variantlib/commands/config/main.py
+++ b/variantlib/commands/config/main.py
@@ -20,7 +20,7 @@ def main(args: list[str]) -> None:
 
     parser.add_argument(
         "command",
-        choices=registered_commands.names,
+        choices=sorted(registered_commands.names),
     )
 
     parser.add_argument(

--- a/variantlib/commands/config/main.py
+++ b/variantlib/commands/config/main.py
@@ -5,6 +5,8 @@ from __future__ import annotations
 import argparse
 import sys
 
+from variantlib import __package_name__
+
 if sys.version_info >= (3, 10):
     from importlib.metadata import entry_points
 else:
@@ -14,7 +16,7 @@ else:
 def main(args: list[str]) -> None:
     registered_commands = entry_points(group="variantlib.actions.config")
 
-    parser = argparse.ArgumentParser(prog="variantlib configuration")
+    parser = argparse.ArgumentParser(prog=f"{__package_name__} config")
 
     parser.add_argument(
         "command",

--- a/variantlib/commands/config/setup.py
+++ b/variantlib/commands/config/setup.py
@@ -8,6 +8,7 @@ from pathlib import Path
 import tomlkit
 from tomlkit.toml_file import TOMLFile
 
+from variantlib import __package_name__
 from variantlib.commands.config.setup_interfaces.console_ui import ConsoleUI
 from variantlib.commands.config.setup_interfaces.urwid_ui import UrwidUI
 from variantlib.configuration import ConfigEnvironments
@@ -62,7 +63,7 @@ INSTRUCTIONS = """
 
 def setup(args: list[str]) -> None:
     parser = argparse.ArgumentParser(
-        prog="setup",
+        prog=f"{__package_name__} config setup",
         description="CLI interface to interactively set configuration up",
     )
     parser.add_argument(

--- a/variantlib/commands/config/show.py
+++ b/variantlib/commands/config/show.py
@@ -7,6 +7,7 @@ import sys
 
 import tomlkit
 
+from variantlib import __package_name__
 from variantlib.configuration import ConfigEnvironments
 from variantlib.configuration import VariantConfiguration
 from variantlib.configuration import get_configuration_files
@@ -17,7 +18,7 @@ logger = logging.getLogger(__name__)
 
 def show(args: list[str]) -> None:
     parser = argparse.ArgumentParser(
-        prog="show",
+        prog=f"{__package_name__} config show",
         description="CLI interface to interactively show active configuration.",
     )
 

--- a/variantlib/commands/generate_index_json.py
+++ b/variantlib/commands/generate_index_json.py
@@ -10,6 +10,7 @@ import pathlib
 import zipfile
 from collections import defaultdict
 
+from variantlib import __package_name__
 from variantlib.constants import METADATA_VARIANT_PROPERTY_HEADER
 from variantlib.constants import METADATA_VARIANT_PROVIDER_HEADER
 from variantlib.constants import VALIDATION_WHEEL_NAME_REGEX
@@ -25,7 +26,7 @@ logger = logging.getLogger(__name__)
 
 def generate_index_json(args: list[str]) -> None:
     parser = argparse.ArgumentParser(
-        prog="generate_index_json",
+        prog=f"{__package_name__} generate-index-json",
         description="Generate a JSON index of all package variants",
     )
     parser.add_argument(

--- a/variantlib/commands/main.py
+++ b/variantlib/commands/main.py
@@ -34,7 +34,7 @@ def main() -> None:
     )
     parser.add_argument(
         "command",
-        choices=registered_commands.names,
+        choices=sorted(registered_commands.names),
     )
     parser.add_argument(
         "args",

--- a/variantlib/commands/make_variant.py
+++ b/variantlib/commands/make_variant.py
@@ -10,6 +10,7 @@ import pathlib
 import shutil
 import zipfile
 
+from variantlib import __package_name__
 from variantlib.api import VariantDescription
 from variantlib.api import VariantProperty
 from variantlib.api import set_variant_metadata
@@ -28,7 +29,7 @@ METADATA_POLICY = email.policy.EmailPolicy(
 
 def make_variant(args: list[str]) -> None:
     parser = argparse.ArgumentParser(
-        prog="make_variant",
+        prog=f"{__package_name__} make-variant",
         description="Transform a normal Wheel into a Wheel Variant.",
     )
 

--- a/variantlib/commands/plugins/get_all_configs.py
+++ b/variantlib/commands/plugins/get_all_configs.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import argparse
 import logging
 
+from variantlib import __package_name__
 from variantlib.commands.plugins._display_configs import display_configs
 from variantlib.loader import PluginLoader
 
@@ -11,7 +12,7 @@ logger = logging.getLogger(__name__)
 
 def get_all_configs(args: list[str]) -> None:
     parser = argparse.ArgumentParser(
-        prog="get-all-configs",
+        prog=f"{__package_name__} plugins get-all-configs",
         description="CLI interface to get all valid configs",
     )
 

--- a/variantlib/commands/plugins/get_supported_configs.py
+++ b/variantlib/commands/plugins/get_supported_configs.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import argparse
 import logging
 
+from variantlib import __package_name__
 from variantlib.commands.plugins._display_configs import display_configs
 from variantlib.loader import PluginLoader
 
@@ -11,7 +12,7 @@ logger = logging.getLogger(__name__)
 
 def get_supported_configs(args: list[str]) -> None:
     parser = argparse.ArgumentParser(
-        prog="get-supported-configs",
+        prog=f"{__package_name__} plugins get-supported-configs",
         description="CLI interface to get all supported configs on the machine",
     )
 

--- a/variantlib/commands/plugins/list_plugins.py
+++ b/variantlib/commands/plugins/list_plugins.py
@@ -4,6 +4,7 @@ import argparse
 import logging
 import sys
 
+from variantlib import __package_name__
 from variantlib.loader import PluginLoader
 
 logger = logging.getLogger(__name__)
@@ -11,7 +12,7 @@ logger = logging.getLogger(__name__)
 
 def list_plugins(args: list[str]) -> None:
     parser = argparse.ArgumentParser(
-        prog="list-plugins",
+        prog=f"{__package_name__} plugins list-plugins",
         description="CLI interface to list plugins",
     )
 

--- a/variantlib/commands/plugins/main.py
+++ b/variantlib/commands/plugins/main.py
@@ -20,7 +20,7 @@ def main(args: list[str]) -> None:
 
     parser.add_argument(
         "command",
-        choices=registered_commands.names,
+        choices=sorted(registered_commands.names),
     )
 
     parser.add_argument(

--- a/variantlib/commands/plugins/main.py
+++ b/variantlib/commands/plugins/main.py
@@ -5,6 +5,8 @@ from __future__ import annotations
 import argparse
 import sys
 
+from variantlib import __package_name__
+
 if sys.version_info >= (3, 10):
     from importlib.metadata import entry_points
 else:
@@ -14,7 +16,7 @@ else:
 def main(args: list[str]) -> None:
     registered_commands = entry_points(group="variantlib.actions.plugins")
 
-    parser = argparse.ArgumentParser(prog="variantlib plugins")
+    parser = argparse.ArgumentParser(prog=f"{__package_name__} plugins")
 
     parser.add_argument(
         "command",

--- a/variantlib/commands/unmake_variant.py
+++ b/variantlib/commands/unmake_variant.py
@@ -10,6 +10,7 @@ import pathlib
 import shutil
 import zipfile
 
+from variantlib import __package_name__
 from variantlib.constants import METADATA_VARIANT_HASH_HEADER
 from variantlib.constants import METADATA_VARIANT_PROPERTY_HEADER
 from variantlib.constants import METADATA_VARIANT_PROVIDER_HEADER
@@ -26,7 +27,7 @@ METADATA_POLICY = email.policy.EmailPolicy(
 
 def unmake_variant(args: list[str]) -> None:
     parser = argparse.ArgumentParser(
-        prog="unmake_variant",
+        prog=f"{__package_name__} unmake-variant",
         description="Transform a variant Wheel into a normal Wheel.",
     )
 


### PR DESCRIPTION
Ensure that all commands use hyphens rather than underscores, and fix `prog_name` in all commands to use `__package_name__`, and to list full command path rather than just the command name.