### PR TITLE
Use more correct initial ordering in `variantlib config setup`

### DIFF
--- a/variantlib/commands/config/setup_interfaces/console_ui.py
+++ b/variantlib/commands/config/setup_interfaces/console_ui.py
@@ -112,7 +112,7 @@ class ConsoleUI:
         key: str,
         known_values: list[str],
         known_values_required: bool,
-    ) -> None:
+    ) -> list[str]:
         toml_values = tomldoc.setdefault(key, [])
         unknown_values = sorted(set(toml_values) - set(known_values))
 
@@ -158,3 +158,4 @@ class ConsoleUI:
         toml_values.clear()
         toml_values.extend(new_values)
         sys.stderr.write("\n")
+        return new_values

--- a/variantlib/commands/config/setup_interfaces/urwid_ui.py
+++ b/variantlib/commands/config/setup_interfaces/urwid_ui.py
@@ -114,7 +114,7 @@ class UrwidUI:
         key: str,
         known_values: list[str],
         known_values_required: bool,
-    ) -> None:
+    ) -> list[str]:
         toml_values = tomldoc.setdefault(key, [])
         toml_values_set = set(toml_values)
         all_values = toml_values + [
@@ -213,3 +213,4 @@ class UrwidUI:
 
         toml_values.clear()
         toml_values.extend(new_values)
+        return new_values


### PR DESCRIPTION
Correct the initial ordering of options in `variantlib config setup` so that it matches better the order used by `variantlib`, rather than using lexical order.  More specifically:

1. Enabled namespaces are listed first, in their previous configuration order.  The remaining namespaces are sorted lexically.

2. Enabled features are listed first, in their previous configuration order.  The remaining features are sorted according to namespace priorities (respecting the new configuration) and then their plugin ordering (rather than lexically, as previously).

3. Enabled properties are listed first, in their previous configuration order.  The remaining properties are sorted using the resolved sort function, respecting the new namespace and feature priorities, and the plugin ordering of values.