### PR TITLE
[Vendoring] PyPA/Build Env Logic

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -42,6 +42,7 @@ jobs:
       - name: Install the package and test dependencies
         run: |
           uv venv
+          uv pip install --upgrade pip
           uv pip install -e '.[test]'
       - name: Run tests
         run: uv run --no-project pytest

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -51,7 +51,9 @@ test = [
     "pytest-mock>=3.14.0,<4.0.0",
     "pytest-runner>=6.0.0,<7.0.0",
     "pytest-ordering>=0.6,<1.0.0",
+    "virtualenv>=20.0.0,<21.0.0",
     "tomlkit>=0.13,<0.14",
+    "uv>=0.7,<0.8",
 ]
 
 [project.scripts]
@@ -78,7 +80,13 @@ get-supported-configs = "variantlib.commands.plugins.get_supported_configs:get_s
 
 [tool.pytest.ini_options]
 testpaths = ["tests/"]
+log_cli_level = "info"
 addopts = "-vvv --cov=variantlib --cov-report=term-missing"
+markers = [
+  "isolated",
+  "pypy3323bug",
+  "network",
+]
 
 [tool.mypy]
 disallow_untyped_defs = true

--- a/tests/packages/test-flit/pyproject.toml
+++ b/tests/packages/test-flit/pyproject.toml
@@ -1,0 +1,16 @@
+
+# Project Copied from: https://github.com/pypa/build/blob/main/tests/packages/test-flit/pyproject.toml
+
+[build-system]
+requires = ['flit_core >=2,<3']
+build-backend = 'flit_core.buildapi'
+
+[tool.flit.metadata]
+module = 'test_flit'
+author = 'Filipe Laíns'
+author-email = 'lains@archlinux.org'
+classifiers = [
+    'License :: OSI Approved :: MIT License',
+    'Programming Language :: Python :: 2.7',
+    'Programming Language :: Python :: 3',
+]

--- a/tests/packages/test-flit/test_flit/__init__.py
+++ b/tests/packages/test-flit/test_flit/__init__.py
@@ -1,0 +1,7 @@
+# SPDX-License-Identifier: MIT
+
+"""
+test_flit - Example flit package
+"""
+
+__version__ = "1.0.0"

--- a/tests/test_installer.py
+++ b/tests/test_installer.py
@@ -1,0 +1,360 @@
+# SPDX-License-Identifier: MIT
+
+"""
+This file is imported from https://github.com/pypa/build/blob/35d86b8/tests/test_util.py
+Some modifications have been made to make the code standalone.
+
+If possible, this code should stay as close to the original as possible.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import logging
+import shutil
+import subprocess
+import sys
+import sysconfig
+import typing
+from pathlib import Path
+from types import SimpleNamespace
+
+import pytest
+from packaging.version import Version
+
+import variantlib.installer as vinstall
+
+if typing.TYPE_CHECKING:
+    import pytest_mock
+
+IS_PYPY = sys.implementation.name == "pypy"
+IS_WINDOWS = sys.platform.startswith("win")
+
+MISSING_UV = importlib.util.find_spec("uv") is None and not shutil.which("uv")
+
+
+@pytest.fixture
+def local_pip(monkeypatch):
+    monkeypatch.setattr(vinstall._PipBackend, "_has_valid_outer_pip", None)  # noqa: SLF001
+
+
+@pytest.fixture(autouse=True, params=[False])
+def has_virtualenv(request, monkeypatch):
+    if request.param is not None:
+        monkeypatch.setattr(vinstall._PipBackend, "_has_virtualenv", request.param)  # noqa: SLF001
+
+
+@pytest.mark.isolated
+def test_isolation():
+    subprocess.check_call([sys.executable, "-c", "import variantlib.installer"])  # noqa: S603
+    with vinstall.DefaultIsolatedEnv() as env:  # noqa: SIM117
+        with pytest.raises(subprocess.CalledProcessError):  # noqa: PT012
+            debug = "import sys; import os; print(os.linesep.join(sys.path));"
+            subprocess.check_call(  # noqa: S603
+                [env.python_executable, "-c", f"{debug} import variantlib.installer"]
+            )
+
+
+@pytest.mark.skipif(IS_PYPY, reason="PyPy3 uses get path to create and provision venv")
+@pytest.mark.skipif(sys.platform != "darwin", reason="workaround for Apple Python")
+def test_can_get_venv_paths_with_conflicting_default_scheme(
+    mocker: pytest_mock.MockerFixture,
+):
+    get_scheme_names = mocker.patch(
+        "sysconfig.get_scheme_names", return_value=("osx_framework_library",)
+    )
+    with vinstall.DefaultIsolatedEnv():
+        pass
+    assert get_scheme_names.call_count == 1
+
+
+SCHEME_NAMES = sysconfig.get_scheme_names()
+
+
+@pytest.mark.skipif(
+    "posix_local" not in SCHEME_NAMES, reason="workaround for Debian/Ubuntu Python"
+)
+@pytest.mark.skipif(
+    "venv" in SCHEME_NAMES, reason="different call if venv is in scheme names"
+)
+def test_can_get_venv_paths_with_posix_local_default_scheme(
+    mocker: pytest_mock.MockerFixture,
+):
+    get_paths = mocker.spy(sysconfig, "get_paths")
+    # We should never call this, but we patch it to ensure failure if we do
+    get_default_scheme = mocker.patch(
+        "sysconfig.get_default_scheme", return_value="posix_local"
+    )
+    with vinstall.DefaultIsolatedEnv():
+        pass
+    get_paths.assert_called_once_with(scheme="posix_prefix", vars=mocker.ANY)
+    assert get_default_scheme.call_count == 0
+
+
+def test_venv_executable_missing_post_creation(
+    mocker: pytest_mock.MockerFixture,
+):
+    venv_create = mocker.patch("venv.EnvBuilder.create")
+    with pytest.raises(  # noqa: SIM117
+        RuntimeError, match="Virtual environment creation failed, executable .* missing"
+    ):
+        with vinstall.DefaultIsolatedEnv():
+            pass
+    assert venv_create.call_count == 1
+
+
+@typing.no_type_check
+def test_isolated_env_abstract():
+    with pytest.raises(TypeError):
+        vinstall.IsolatedEnv()
+
+    class PartialEnvA(vinstall.IsolatedEnv):
+        @property
+        def executable(self):
+            raise NotImplementedError
+
+    with pytest.raises(TypeError):
+        PartialEnvA()
+
+    class PartialEnvB(vinstall.IsolatedEnv):
+        def make_extra_environ(self):
+            raise NotImplementedError
+
+    with pytest.raises(TypeError):
+        PartialEnvB()
+
+
+@pytest.mark.pypy3323bug
+def test_isolated_env_log(
+    caplog: pytest.LogCaptureFixture,
+    mocker: pytest_mock.MockerFixture,
+):
+    caplog.set_level(logging.DEBUG)
+    mocker.patch("variantlib.installer.run_subprocess")
+
+    with vinstall.DefaultIsolatedEnv() as env:
+        env.install(["something"])
+
+    assert [(record.levelname, record.message) for record in caplog.records] == [
+        ("INFO", "Creating isolated environment: venv+pip ..."),
+        ("INFO", "Installing packages in isolated environment:\n- something"),
+    ]
+
+
+@pytest.mark.isolated
+@pytest.mark.usefixtures("local_pip")
+def test_default_pip_is_never_too_old():
+    with vinstall.DefaultIsolatedEnv() as env:
+        version = subprocess.check_output(  # noqa: S603
+            [env.python_executable, "-c", 'import pip; print(pip.__version__, end="")'],
+            encoding="utf-8",
+        )
+        assert Version(version) >= Version("19.1")
+
+
+@pytest.mark.isolated
+@pytest.mark.parametrize("pip_version", ["20.2.0", "20.3.0", "21.0.0", "21.0.1"])
+@pytest.mark.parametrize("arch", ["x86_64", "arm64"])
+@pytest.mark.usefixtures("local_pip")
+def test_pip_needs_upgrade_mac_os_11(
+    mocker: pytest_mock.MockerFixture,
+    pip_version: str,
+    arch: str,
+):
+    run_subprocess = mocker.patch("variantlib.installer.run_subprocess")
+    mocker.patch("platform.system", return_value="Darwin")
+    mocker.patch("platform.mac_ver", return_value=("11.0", ("", "", ""), arch))
+    mocker.patch(
+        "variantlib.installer.distributions",
+        return_value=(SimpleNamespace(version=pip_version),),
+    )
+
+    min_pip_version = "20.3.0" if arch == "x86_64" else "21.0.1"
+
+    with vinstall.DefaultIsolatedEnv() as env:
+        if Version(pip_version) < Version(min_pip_version):
+            assert run_subprocess.call_args_list == [
+                mocker.call(
+                    [
+                        env.python_executable,
+                        "-Im",
+                        "pip",
+                        "install",
+                        f"pip>={min_pip_version}",
+                    ]
+                ),
+                mocker.call(
+                    [
+                        env.python_executable,
+                        "-Im",
+                        "pip",
+                        "uninstall",
+                        "-y",
+                        "setuptools",
+                    ]
+                ),
+            ]
+        else:
+            run_subprocess.assert_called_once_with(
+                [env.python_executable, "-Im", "pip", "uninstall", "-y", "setuptools"],
+            )
+
+
+@pytest.mark.parametrize(
+    "has_symlink", [True, False] if sys.platform.startswith("win") else [True]
+)
+def test_venv_symlink(
+    mocker: pytest_mock.MockerFixture,
+    has_symlink: bool,
+):
+    if has_symlink:
+        mocker.patch("os.symlink")
+        mocker.patch("os.unlink")
+    else:
+        mocker.patch("os.symlink", side_effect=OSError())
+
+    # Cache must be cleared to rerun
+    vinstall._fs_supports_symlink.cache_clear()  # noqa: SLF001
+    supports_symlink = vinstall._fs_supports_symlink()  # noqa: SLF001
+    vinstall._fs_supports_symlink.cache_clear()  # noqa: SLF001
+
+    assert supports_symlink is has_symlink
+
+
+def test_install_short_circuits(
+    mocker: pytest_mock.MockerFixture,
+):
+    with vinstall.DefaultIsolatedEnv() as env:
+        install_requirements = mocker.patch.object(
+            env._env_backend,  # noqa: SLF001
+            "install_requirements",
+        )
+
+        env.install([])
+        install_requirements.assert_not_called()
+
+        env.install(["foo"])
+        install_requirements.assert_called_once()
+
+
+@pytest.mark.usefixtures("local_pip")
+def test_default_impl_install_cmd_well_formed(mocker: pytest_mock.MockerFixture):
+    with vinstall.DefaultIsolatedEnv() as env:
+        run_subprocess = mocker.patch("variantlib.installer.run_subprocess")
+
+        env.install(["some", "requirements"])
+
+        run_subprocess.assert_called_once_with(
+            [
+                env.python_executable,
+                "-Im",
+                "pip",
+                "install",
+                "--use-pep517",
+                "--no-warn-script-location",
+                "--no-compile",
+                "-r",
+                mocker.ANY,
+            ]
+        )
+
+
+@pytest.mark.skipif(IS_PYPY, reason="uv cannot find PyPy executable")
+@pytest.mark.skipif(MISSING_UV, reason="uv executable not found")
+def test_uv_impl_install_cmd_well_formed(mocker: pytest_mock.MockerFixture):
+    with vinstall.DefaultIsolatedEnv(installer="uv") as env:
+        run_subprocess = mocker.patch("variantlib.installer.run_subprocess")
+
+        env.install(["some", "requirements"])
+
+        (install_call,) = run_subprocess.call_args_list
+        assert len(install_call.args) == 1
+        assert install_call.args[0][1:] == [
+            "pip",
+            "install",
+            "some",
+            "requirements",
+        ]
+        assert len(install_call.kwargs) == 1
+        assert install_call.kwargs["env"]["VIRTUAL_ENV"] == env.path
+
+
+@pytest.mark.usefixtures("local_pip")
+@pytest.mark.parametrize(
+    ("installer", "env_backend_display_name", "has_virtualenv"),
+    [
+        ("pip", "venv+pip", False),
+        ("pip", "virtualenv+pip", True),
+        ("pip", "virtualenv+pip", None),  # Fall-through
+        pytest.param(
+            "uv",
+            "venv+uv",
+            None,
+            marks=pytest.mark.skipif(MISSING_UV, reason="uv executable not found"),
+        ),
+    ],
+    indirect=("has_virtualenv",),
+)
+def test_venv_creation(
+    installer: vinstall.Installer,
+    env_backend_display_name: str,
+):
+    with vinstall.DefaultIsolatedEnv(installer=installer) as env:
+        assert env._env_backend.display_name == env_backend_display_name  # noqa: SLF001
+
+
+@pytest.mark.network
+@pytest.mark.usefixtures("local_pip")
+@pytest.mark.parametrize(
+    "installer",
+    [
+        "pip",
+        pytest.param(
+            "uv",
+            marks=[
+                pytest.mark.xfail(
+                    IS_PYPY and IS_WINDOWS and sys.version_info < (3, 9),
+                    reason="uv cannot find PyPy 3.8 executable on Windows",
+                ),
+                pytest.mark.skipif(MISSING_UV, reason="uv executable not found"),
+            ],
+        ),
+    ],
+)
+def test_requirement_installation(
+    package_test_flit: str,
+    installer: vinstall.Installer,
+):
+    with vinstall.DefaultIsolatedEnv(installer=installer) as env:
+        env.install([f"test-flit @ {Path(package_test_flit).as_uri()}"])
+
+
+@pytest.mark.skipif(MISSING_UV, reason="uv executable not found")
+def test_external_uv_detection_success(
+    caplog: pytest.LogCaptureFixture,
+    mocker: pytest_mock.MockerFixture,
+):
+    mocker.patch.dict(sys.modules, {"uv": None})
+
+    with vinstall.DefaultIsolatedEnv(installer="uv"):
+        pass
+
+    assert any(
+        r.message
+        == (
+            "Using external uv from "
+            f"`{shutil.which('uv', path=sysconfig.get_path('scripts'))}`"
+        )
+        for r in caplog.records
+    )
+
+
+def test_external_uv_detection_failure(
+    mocker: pytest_mock.MockerFixture,
+):
+    mocker.patch.dict(sys.modules, {"uv": None})
+    mocker.patch("shutil.which", return_value=None)
+
+    with pytest.raises(RuntimeError, match="uv executable not found"):  # noqa: SIM117
+        with vinstall.DefaultIsolatedEnv(installer="uv"):
+            pass

--- a/tests/test_installer_utils.py
+++ b/tests/test_installer_utils.py
@@ -1,0 +1,185 @@
+# SPDX-License-Identifier: MIT
+
+"""
+This file is imported from https://github.com/pypa/build/blob/35d86b8/tests/test_projectbuilder.py
+Some modifications have been made to make the code standalone.
+
+If possible, this code should stay as close to the original as possible.
+"""
+
+from __future__ import annotations
+
+import sys
+import textwrap
+
+import pytest
+
+from variantlib.installer_utils import check_dependency
+
+if sys.version_info >= (3, 10):
+    import importlib.metadata as importlib_metadata
+    from importlib.metadata import Distribution
+    from importlib.metadata import PackageNotFoundError
+else:
+    import importlib_metadata
+    from importlib_metadata import Distribution
+    from importlib_metadata import PackageNotFoundError
+
+
+class MockDistribution(Distribution):
+    def locate_file(self, path):  # pragma: no cover
+        return ""
+
+    @classmethod
+    def from_name(cls, name):
+        if name == "extras_dep":
+            return ExtraMockDistribution()
+        if name == "requireless_dep":
+            return RequirelessMockDistribution()
+        if name == "recursive_dep":
+            return RecursiveMockDistribution()
+        if name == "prerelease_dep":
+            return PrereleaseMockDistribution()
+        if name == "circular_dep":
+            return CircularMockDistribution()
+        if name == "nested_circular_dep":
+            return NestedCircularMockDistribution()
+        raise PackageNotFoundError
+
+
+class ExtraMockDistribution(MockDistribution):
+    def read_text(self, filename) -> str | None:
+        if filename == "METADATA":
+            return textwrap.dedent(
+                """
+                Metadata-Version: 2.2
+                Name: extras_dep
+                Version: 1.0.0
+                Provides-Extra: extra-without-associated-deps
+                Provides-Extra: extra-with_unmet-deps
+                Requires-Dist: unmet_dep; extra == 'extra-with-unmet-deps'
+                Provides-Extra: extra-with-met-deps
+                Requires-Dist: extras_dep; extra == 'extra-with-met-deps'
+                Provides-Extra: recursive-extra-with-unmet-deps
+                Requires-Dist: recursive_dep; extra == 'recursive-extra-with-unmet-deps'
+                """
+            ).strip()
+
+        return None
+
+
+class RequirelessMockDistribution(MockDistribution):
+    def read_text(self, filename) -> str | None:
+        if filename == "METADATA":
+            return textwrap.dedent(
+                """
+                Metadata-Version: 2.2
+                Name: requireless_dep
+                Version: 1.0.0
+                """
+            ).strip()
+
+        return None
+
+
+class RecursiveMockDistribution(MockDistribution):
+    def read_text(self, filename) -> str | None:
+        if filename == "METADATA":
+            return textwrap.dedent(
+                """
+                Metadata-Version: 2.2
+                Name: recursive_dep
+                Version: 1.0.0
+                Requires-Dist: recursive_unmet_dep
+                """
+            ).strip()
+
+        return None
+
+
+class PrereleaseMockDistribution(MockDistribution):
+    def read_text(self, filename) -> str | None:
+        if filename == "METADATA":
+            return textwrap.dedent(
+                """
+                Metadata-Version: 2.2
+                Name: prerelease_dep
+                Version: 1.0.1a0
+                """
+            ).strip()
+
+        return None
+
+
+class CircularMockDistribution(MockDistribution):
+    def read_text(self, filename) -> str | None:
+        if filename == "METADATA":
+            return textwrap.dedent(
+                """
+                Metadata-Version: 2.2
+                Name: circular_dep
+                Version: 1.0.0
+                Requires-Dist: nested_circular_dep
+                """
+            ).strip()
+
+        return None
+
+
+class NestedCircularMockDistribution(MockDistribution):
+    def read_text(self, filename) -> str | None:
+        if filename == "METADATA":
+            return textwrap.dedent(
+                """
+                Metadata-Version: 2.2
+                Name: nested_circular_dep
+                Version: 1.0.0
+                Requires-Dist: circular_dep
+                """
+            ).strip()
+
+        return None
+
+
+@pytest.mark.parametrize(
+    ("requirement_string", "expected"),
+    [
+        ("extras_dep", None),
+        ("missing_dep", ("missing_dep",)),
+        ("requireless_dep", None),
+        ("extras_dep[undefined_extra]", None),
+        # would the wheel builder filter this out?
+        ("extras_dep[extra-without-associated-deps]", None),
+        (
+            "extras_dep[extra-with-unmet-deps]",
+            (
+                "extras_dep[extra-with-unmet-deps]",
+                'unmet_dep; extra == "extra-with-unmet-deps"',
+            ),
+        ),
+        (
+            "extras_dep[recursive-extra-with-unmet-deps]",
+            (
+                "extras_dep[recursive-extra-with-unmet-deps]",
+                'recursive_dep; extra == "recursive-extra-with-unmet-deps"',
+                "recursive_unmet_dep",
+            ),
+        ),
+        ("extras_dep[extra-with-met-deps]", None),
+        ('missing_dep; python_version>"10"', None),
+        ('missing_dep; python_version<="1"', None),
+        ('missing_dep; python_version>="1"', ('missing_dep; python_version >= "1"',)),
+        ("extras_dep == 1.0.0", None),
+        ("extras_dep == 2.0.0", ("extras_dep==2.0.0",)),
+        ("extras_dep[extra-without-associated-deps] == 1.0.0", None),
+        (
+            "extras_dep[extra-without-associated-deps] == 2.0.0",
+            ("extras_dep[extra-without-associated-deps]==2.0.0",),
+        ),
+        ("prerelease_dep >= 1.0.0", None),
+        ("circular_dep", None),
+    ],
+)
+def test_check_dependency(monkeypatch, requirement_string, expected):
+    monkeypatch.setattr(importlib_metadata, "Distribution", MockDistribution)
+    assert next(check_dependency(requirement_string), None) == expected

--- a/variantlib/installer.py
+++ b/variantlib/installer.py
@@ -1,0 +1,461 @@
+# SPDX-License-Identifier: MIT
+
+"""
+This file is imported from https://github.com/pypa/build/blob/35d86b8/src/build/env.py
+Some modifications have been made to make the code standalone.
+
+If possible, this code should stay as close to the original as possible.
+"""
+
+from __future__ import annotations
+
+import abc
+import functools
+import importlib.util
+import logging
+import os
+import platform
+import shutil
+import subprocess
+import sys
+import sysconfig
+import tempfile
+import typing
+import warnings
+
+from packaging.version import Version
+
+from variantlib.installer_utils import check_dependency
+
+if typing.TYPE_CHECKING:
+    from collections.abc import Collection
+    from collections.abc import Mapping
+
+if sys.version_info >= (3, 10):
+    from importlib.metadata import distributions
+else:
+    from importlib_metadata import distributions
+
+logger = logging.getLogger(__name__)
+
+Installer = typing.Literal["pip", "uv"]
+
+INSTALLERS = typing.get_args(Installer)
+
+
+def run_subprocess(cmd: list[str], env: Mapping[str, str] | None = None) -> None:
+    subprocess.run(cmd, capture_output=True, check=True, env=env)  # noqa: S603
+
+
+class FailedProcessError(Exception):
+    """
+    Exception raised when a setup or preparation operation fails.
+    """
+
+    def __init__(
+        self, exception: subprocess.CalledProcessError, description: str
+    ) -> None:
+        super().__init__()
+        self.exception = exception
+        self._description = description
+
+    def __str__(self) -> str:
+        return self._description
+
+
+class IsolatedEnv(typing.Protocol):
+    """Isolated build environment ABC."""
+
+    @property
+    @abc.abstractmethod
+    def python_executable(self) -> str:
+        """The Python executable of the isolated environment."""
+
+    @abc.abstractmethod
+    def make_extra_environ(self) -> Mapping[str, str] | None:
+        """Generate additional env vars specific to the isolated environment."""
+
+
+def _has_dependency(
+    name: str, minimum_version_str: str | None = None, /, **distargs: typing.Any
+) -> bool | None:
+    """
+    Given a path, see if a package is present and return True if the version is
+    sufficient for build, False if it is not, None if the package is missing.
+    """
+
+    try:
+        distribution = next(iter(distributions(name=name, **distargs)))
+    except StopIteration:
+        return None
+
+    if minimum_version_str is None:
+        return True
+
+    return Version(distribution.version) >= Version(minimum_version_str)
+
+
+class DefaultIsolatedEnv(IsolatedEnv):
+    """
+    Isolated environment which supports several different underlying implementations.
+    """
+
+    def __init__(
+        self,
+        *,
+        installer: Installer = "pip",
+    ) -> None:
+        self.installer: Installer = installer
+
+    def __enter__(self) -> DefaultIsolatedEnv:  # noqa: PYI034
+        try:
+            path = tempfile.mkdtemp(prefix="build-env-")
+            # Call ``realpath`` to prevent spurious warning from being emitted
+            # that the venv location has changed on Windows for the venv impl.
+            # The username is DOS-encoded in the output of tempfile - the location is
+            # the same but the representation of it is different, which confuses venv.
+            # Ref: https://bugs.python.org/issue46171
+            path = os.path.realpath(path)
+            self._path = path
+
+            self._env_backend: _EnvBackend
+
+            # uv is opt-in only.
+            if self.installer == "uv":
+                self._env_backend = _UvBackend()
+            else:
+                self._env_backend = _PipBackend()
+
+            logger.info(
+                "Creating isolated environment: %(env)s ...",
+                {"env": self._env_backend.display_name},
+            )
+            self._env_backend.create(self._path)
+
+        except Exception:  # cleanup folder if creation fails
+            self.__exit__(*sys.exc_info())
+            raise
+
+        return self
+
+    def __exit__(self, *args: object) -> None:
+        # in case the user already deleted skip remove
+        if os.path.exists(self._path):  # noqa: PTH110
+            shutil.rmtree(self._path)
+
+    @property
+    def path(self) -> str:
+        """The location of the isolated build environment."""
+        return self._path
+
+    @property
+    def python_executable(self) -> str:
+        """The python executable of the isolated build environment."""
+        return self._env_backend.python_executable
+
+    def make_extra_environ(self) -> dict[str, str]:
+        path = os.environ.get("PATH")
+        return {
+            "PATH": os.pathsep.join([self._env_backend.scripts_dir, path])
+            if path is not None
+            else self._env_backend.scripts_dir
+        }
+
+    def install(self, requirements: Collection[str]) -> None:
+        """
+        Install packages from PEP 508 requirements in the isolated build environment.
+
+        :param requirements: PEP 508 requirement specification to install
+
+        :note: Passing non-PEP 508 strings will result in undefined behavior, you
+               *should not* rely on it. It is merely an implementation detail, it may
+               change any time without warning.
+        """
+        if not requirements:
+            return
+
+        logger.info(
+            "Installing packages in isolated environment:\n%(reqs)s",
+            {"reqs": "\n".join(f"- {r}" for r in sorted(requirements))},
+        )
+        self._env_backend.install_requirements(requirements)
+
+
+class _EnvBackend(typing.Protocol):  # pragma: no cover
+    python_executable: str
+    scripts_dir: str
+
+    def create(self, path: str) -> None: ...
+
+    def install_requirements(self, requirements: Collection[str]) -> None: ...
+
+    @property
+    def display_name(self) -> str: ...
+
+
+class _PipBackend(_EnvBackend):
+    def __init__(self) -> None:
+        self._create_with_virtualenv = (
+            not self._has_valid_outer_pip and self._has_virtualenv
+        )
+
+    @functools.cached_property
+    def _has_valid_outer_pip(self) -> bool | None:
+        """
+        This checks for a valid global pip. Returns None if pip is missing, False
+        if pip is too old, and True if it can be used.
+        """
+        # `pip install --python` is nonfunctional on Gentoo debundled pip.
+        # Detect that by checking if pip._vendor` module exists.  However,
+        # searching for pip could yield warnings from _distutils_hack,
+        # so silence them.
+        with warnings.catch_warnings():
+            warnings.simplefilter("ignore")
+            if importlib.util.find_spec("pip._vendor") is None:
+                return False  # pragma: no cover
+
+        # Version to have added the `--python` option.
+        return _has_dependency("pip", "22.3")
+
+    @functools.cached_property
+    def _has_virtualenv(self) -> bool:
+        """
+        virtualenv might be incompatible if it was installed separately
+        from build. This verifies that virtualenv and all of its
+        dependencies are installed as required by build.
+        """
+        from packaging.requirements import Requirement
+
+        name = "virtualenv"
+
+        return importlib.util.find_spec(name) is not None and not any(
+            Requirement(d[1]).name == name
+            for d in check_dependency(f"build[{name}]")
+            if len(d) > 1
+        )
+
+    @staticmethod
+    def _get_minimum_pip_version_str() -> str:
+        if platform.system() == "Darwin":
+            release, _, machine = platform.mac_ver()
+            if int(release[: release.find(".")]) >= 11:
+                # macOS 11+ name scheme change requires 20.3. Intel macOS 11.0 can be
+                # told to report 10.16 for backwards compatibility; but that also fixes
+                # earlier versions of pip so this is only needed for 11+.
+                is_apple_silicon_python = machine != "x86_64"
+                return "21.0.1" if is_apple_silicon_python else "20.3.0"
+
+        # PEP-517 and manylinux1 was first implemented in 19.1
+        return "19.1.0"
+
+    def create(self, path: str) -> None:
+        if self._create_with_virtualenv:
+            import virtualenv
+
+            result = virtualenv.cli_run(
+                [
+                    path,
+                    "--activators",
+                    "",
+                    "--no-setuptools",
+                    "--no-wheel",
+                ],
+                setup_logging=False,
+            )
+
+            # The creator attributes are `pathlib.Path`s.
+            self.python_executable = str(result.creator.exe)
+            self.scripts_dir = str(result.creator.script_dir)
+
+        else:
+            import venv
+
+            with_pip = not self._has_valid_outer_pip
+
+            try:
+                venv.EnvBuilder(
+                    symlinks=_fs_supports_symlink(), with_pip=with_pip
+                ).create(path)
+            except subprocess.CalledProcessError as exc:
+                raise FailedProcessError(
+                    exc, "Failed to create venv. Maybe try installing virtualenv."
+                ) from None
+
+            self.python_executable, self.scripts_dir, purelib = (
+                _find_executable_and_scripts(path)
+            )
+
+            if with_pip:
+                minimum_pip_version_str = self._get_minimum_pip_version_str()
+                if not _has_dependency(
+                    "pip",
+                    minimum_pip_version_str,
+                    path=[purelib],
+                ):
+                    run_subprocess(
+                        [
+                            self.python_executable,
+                            "-Im",
+                            "pip",
+                            "install",
+                            f"pip>={minimum_pip_version_str}",
+                        ]
+                    )
+
+                # Uninstall setuptools from the build env to prevent depending on it
+                # implicitly. Pythons 3.12 and up do not install setuptools, check if
+                # it exists first.
+                if _has_dependency(
+                    "setuptools",
+                    path=[purelib],
+                ):
+                    run_subprocess(
+                        [
+                            self.python_executable,
+                            "-Im",
+                            "pip",
+                            "uninstall",
+                            "-y",
+                            "setuptools",
+                        ]
+                    )
+
+    def install_requirements(self, requirements: Collection[str]) -> None:
+        # pip does not honour environment markers in command line arguments
+        # but it does from requirement files.
+        with tempfile.NamedTemporaryFile(
+            "w", prefix="build-reqs-", suffix=".txt", delete=False, encoding="utf-8"
+        ) as req_file:
+            req_file.write(os.linesep.join(requirements))
+
+        try:
+            if self._has_valid_outer_pip:
+                cmd = [sys.executable, "-m", "pip", "--python", self.python_executable]
+            else:
+                cmd = [self.python_executable, "-Im", "pip"]
+
+            cmd += [
+                "install",
+                "--use-pep517",
+                "--no-warn-script-location",
+                "--no-compile",
+                "-r",
+                os.path.abspath(req_file.name),  # noqa: PTH100
+            ]
+            run_subprocess(cmd)
+
+        finally:
+            os.unlink(req_file.name)  # noqa: PTH108
+
+    @property
+    def display_name(self) -> str:
+        return "virtualenv+pip" if self._create_with_virtualenv else "venv+pip"
+
+
+class _UvBackend(_EnvBackend):
+    def create(self, path: str) -> None:
+        import venv
+
+        self._env_path = path
+
+        try:
+            import uv  # type: ignore  # noqa: PGH003
+
+            self._uv_bin = uv.find_uv_bin()
+        except (ModuleNotFoundError, FileNotFoundError):
+            uv_bin = shutil.which("uv")
+            if uv_bin is None:
+                msg = "uv executable not found"
+                raise RuntimeError(msg) from None
+
+            logger.info("Using external uv from `%s`", uv_bin)
+            self._uv_bin = uv_bin
+
+        venv.EnvBuilder(symlinks=_fs_supports_symlink(), with_pip=False).create(
+            self._env_path
+        )
+        self.python_executable, self.scripts_dir, _ = _find_executable_and_scripts(
+            self._env_path
+        )
+
+    def install_requirements(self, requirements: Collection[str]) -> None:
+        cmd = [self._uv_bin, "pip"]
+        run_subprocess(
+            [*cmd, "install", *requirements],
+            env={**os.environ, "VIRTUAL_ENV": self._env_path},
+        )
+
+    @property
+    def display_name(self) -> str:
+        return "venv+uv"
+
+
+@functools.cache
+def _fs_supports_symlink() -> bool:
+    """Return True if symlinks are supported"""
+    # Using definition used by venv.main()
+    if os.name != "nt":
+        return True
+
+    # Windows may support symlinks (setting in Windows 10)
+    with tempfile.NamedTemporaryFile(prefix="build-symlink-") as tmp_file:
+        dest = f"{tmp_file}-b"
+        try:
+            os.symlink(tmp_file.name, dest)
+            os.unlink(dest)  # noqa: PTH108
+        except (OSError, NotImplementedError, AttributeError):
+            return False
+        return True
+
+
+def _find_executable_and_scripts(path: str) -> tuple[str, str, str]:
+    """
+    Detect the Python executable and script folder of a virtual environment.
+
+    :param path: The location of the virtual environment
+    :return: The Python executable, script folder, and purelib folder
+    """
+    config_vars = (
+        sysconfig.get_config_vars().copy()
+    )  # globally cached, copy before altering it
+    config_vars["base"] = path
+    scheme_names = sysconfig.get_scheme_names()
+    if "venv" in scheme_names:
+        # Python distributors with custom default installation scheme can set a
+        # scheme that can't be used to expand the paths in a venv.
+        # This can happen if build itself is not installed in a venv.
+        # The distributors are encouraged to set a "venv" scheme to be used for this.
+        # See https://bugs.python.org/issue45413
+        # and https://github.com/pypa/virtualenv/issues/2208
+        paths = sysconfig.get_paths(scheme="venv", vars=config_vars)
+    elif "posix_local" in scheme_names:
+        # The Python that ships on Debian/Ubuntu varies the default scheme to
+        # install to /usr/local
+        # But it does not (yet) set the "venv" scheme.
+        # If we're the Debian "posix_local" scheme is available, but "venv"
+        # is not, we use "posix_prefix" instead which is venv-compatible there.
+        paths = sysconfig.get_paths(scheme="posix_prefix", vars=config_vars)
+    elif "osx_framework_library" in scheme_names:
+        # The Python that ships with the macOS developer tools varies the
+        # default scheme depending on whether the ``sys.prefix`` is part of a framework.
+        # But it does not (yet) set the "venv" scheme.
+        # If the Apple-custom "osx_framework_library" scheme is available but "venv"
+        # is not, we use "posix_prefix" instead which is venv-compatible there.
+        paths = sysconfig.get_paths(scheme="posix_prefix", vars=config_vars)
+    else:
+        paths = sysconfig.get_paths(vars=config_vars)
+
+    executable = os.path.join(  # noqa: PTH118
+        paths["scripts"], "python.exe" if os.name == "nt" else "python"
+    )
+    if not os.path.exists(executable):  # noqa: PTH110
+        msg = f"Virtual environment creation failed, executable {executable} missing"
+        raise RuntimeError(msg)
+
+    return executable, paths["scripts"], paths["purelib"]
+
+
+__all__ = [
+    "DefaultIsolatedEnv",
+    "IsolatedEnv",
+]

--- a/variantlib/installer_utils.py
+++ b/variantlib/installer_utils.py
@@ -1,0 +1,89 @@
+# SPDX-License-Identifier: MIT
+
+"""
+This file is imported from https://github.com/pypa/build/blob/35d86b8/src/build/_util.py
+Some modifications have been made to make the code standalone.
+
+If possible, this code should stay as close to the original as possible.
+"""
+
+from __future__ import annotations
+
+import re
+import sys
+from typing import TYPE_CHECKING
+
+import packaging.requirements
+
+if sys.version_info >= (3, 10):
+    from importlib.metadata import PackageNotFoundError
+    from importlib.metadata import distribution
+else:
+    from importlib_metadata import PackageNotFoundError
+    from importlib_metadata import distribution
+
+if TYPE_CHECKING:
+    from collections.abc import Iterator
+    from collections.abc import Set as AbstractSet
+
+_WHEEL_FILENAME_REGEX = re.compile(
+    r"(?P<distribution>.+)-(?P<version>.+)"
+    r"(-(?P<build_tag>.+))?-(?P<python_tag>.+)"
+    r"-(?P<abi_tag>.+)-(?P<platform_tag>.+)\.whl"
+)
+
+
+def check_dependency(
+    req_string: str,
+    ancestral_req_strings: tuple[str, ...] = (),
+    parent_extras: AbstractSet[str] = frozenset(),
+) -> Iterator[tuple[str, ...]]:
+    """
+    Verify that a dependency and all of its dependencies are met.
+
+    :param req_string: Requirement string
+    :param parent_extras: Extras (eg. "test" in myproject[test])
+    :yields: Unmet dependencies
+    """
+
+    # from ._compat import importlib
+
+    req = packaging.requirements.Requirement(req_string)
+    normalised_req_string = str(req)
+
+    # ``Requirement`` doesn't implement ``__eq__`` so we cannot compare reqs for
+    # equality directly but the string representation is stable.
+    if normalised_req_string in ancestral_req_strings:
+        # cyclical dependency, already checked.
+        return
+
+    if req.marker:
+        extras = frozenset(("",)).union(parent_extras)
+        # a requirement can have multiple extras but ``evaluate`` can
+        # only check one at a time.
+        if all(not req.marker.evaluate(environment={"extra": e}) for e in extras):
+            # if the marker conditions are not met, we pretend that the
+            # dependency is satisfied.
+            return
+
+    try:
+        dist = distribution(req.name)
+    except PackageNotFoundError:
+        # dependency is not installed in the environment.
+        yield (*ancestral_req_strings, normalised_req_string)
+    else:
+        if req.specifier and not req.specifier.contains(dist.version, prereleases=True):
+            # the installed version is incompatible.
+            yield (*ancestral_req_strings, normalised_req_string)
+        elif dist.requires:
+            for other_req_string in dist.requires:
+                # yields transitive dependencies that are not satisfied.
+                yield from check_dependency(
+                    other_req_string,
+                    (*ancestral_req_strings, normalised_req_string),
+                    req.extras,
+                )
+
+
+def parse_wheel_filename(filename: str) -> re.Match[str] | None:
+    return _WHEEL_FILENAME_REGEX.match(filename)


### PR DESCRIPTION
I added the core `build.env` logic as vendored files into this PR.

We will need this to later auto-install plugins.

I saw that you contributed to `pypa/build` so I would think you are pretty familiar with that part of the code which should help to speed up our development.

I also don't think it's really necessary to re-implement the wheel. This implementation works and is well tested.

I made sure to properly credit where these files come from - leave this original license.
I had to adapt some things to satisfy ruff / mypy - I tried to keep changes to the absolute minimum.

In the future I could imagine some bits end up slightly changing like. It's obviously very "build" oriented.

We can either merge this today or wait to need it - In any case it's ready.
Unless you have a better idea ?