### PR TITLE
New API bits for pip: plugin loading, and wheel file supported check

### DIFF
--- a/tests/test_dist_metadata.py
+++ b/tests/test_dist_metadata.py
@@ -1,0 +1,64 @@
+from __future__ import annotations
+
+from email import message_from_string
+
+from variantlib.dist_metadata import DistMetadata
+from variantlib.models.variant import VariantDescription
+from variantlib.models.variant import VariantFeature
+from variantlib.models.variant import VariantProperty
+from variantlib.pyproject_toml import ProviderInfo
+
+TEST_METADATA = """\
+Metadata-Version: 2.1
+Name: test-package
+Version: 1.2.3
+Variant-property: ns1 :: f1 :: p1
+Variant-property: ns1 :: f2 :: p2
+Variant-property: ns2 :: f1 :: p1
+Variant-hash: 67fcaf38
+Variant-requires: ns1: ns1-provider >= 1.2.3
+Variant-plugin-api: ns1: ns1_provider.plugin:NS1Plugin
+Variant-requires: ns2: ns2_provider; python_version >= '3.11'
+Variant-requires: ns2: old_ns2_provider; python_version < '3.11'
+Variant-plugin-api: ns2: ns2_provider:Plugin
+Variant-default-namespace-priorities: ns1, ns2
+Variant-default-feature-priorities: ns2 :: f1, ns1 :: f2
+Variant-default-property-priorities: ns1 :: f2 :: p1, ns2 :: f1 :: p2
+
+long description
+of a package
+"""
+
+
+def test_dist_metadata():
+    metadata = DistMetadata(message_from_string(TEST_METADATA))
+    assert metadata.variant_hash == "67fcaf38"
+    assert metadata.variant_desc == VariantDescription(
+        [
+            VariantProperty("ns1", "f1", "p1"),
+            VariantProperty("ns1", "f2", "p2"),
+            VariantProperty("ns2", "f1", "p1"),
+        ]
+    )
+    assert metadata.namespace_priorities == ["ns1", "ns2"]
+    assert metadata.feature_priorities == [
+        VariantFeature("ns2", "f1"),
+        VariantFeature("ns1", "f2"),
+    ]
+    assert metadata.property_priorities == [
+        VariantProperty("ns1", "f2", "p1"),
+        VariantProperty("ns2", "f1", "p2"),
+    ]
+    assert metadata.providers == {
+        "ns1": ProviderInfo(
+            requires=["ns1-provider >= 1.2.3"],
+            plugin_api="ns1_provider.plugin:NS1Plugin",
+        ),
+        "ns2": ProviderInfo(
+            requires=[
+                "ns2_provider; python_version >= '3.11'",
+                "old_ns2_provider; python_version < '3.11'",
+            ],
+            plugin_api="ns2_provider:Plugin",
+        ),
+    }

--- a/tests/test_pyproject_toml.py
+++ b/tests/test_pyproject_toml.py
@@ -68,13 +68,16 @@ def test_pyproject_toml():
         VariantProperty("ns2", "f1", "p2"),
     ]
     assert pyproj.providers == {
-        "ns1": ProviderInfo(["ns1-provider >= 1.2.3"], "ns1_provider.plugin:NS1Plugin"),
+        "ns1": ProviderInfo(
+            requires=["ns1-provider >= 1.2.3"],
+            plugin_api="ns1_provider.plugin:NS1Plugin",
+        ),
         "ns2": ProviderInfo(
-            [
+            requires=[
                 "ns2_provider; python_version >= '3.11'",
                 "old_ns2_provider; python_version < '3.11'",
             ],
-            "ns2_provider:Plugin",
+            plugin_api="ns2_provider:Plugin",
         ),
     }
 
@@ -85,13 +88,16 @@ def test_pyproject_toml_minimal():
     assert pyproj.feature_priorities == []
     assert pyproj.property_priorities == []
     assert pyproj.providers == {
-        "ns1": ProviderInfo(["ns1-provider >= 1.2.3"], "ns1_provider.plugin:NS1Plugin"),
+        "ns1": ProviderInfo(
+            requires=["ns1-provider >= 1.2.3"],
+            plugin_api="ns1_provider.plugin:NS1Plugin",
+        ),
         "ns2": ProviderInfo(
-            [
+            requires=[
                 "ns2_provider; python_version >= '3.11'",
                 "old_ns2_provider; python_version < '3.11'",
             ],
-            "ns2_provider:Plugin",
+            plugin_api="ns2_provider:Plugin",
         ),
     }
 

--- a/tests/test_pyproject_toml.py
+++ b/tests/test_pyproject_toml.py
@@ -158,7 +158,7 @@ def test_invalid_priority_value(key: str, value: list[str]):
     with pytest.raises(
         ValidationError,
         match=rf"{PYPROJECT_TOML_TOP_KEY}\.{PYPROJECT_TOML_DEFAULT_PRIO_KEY}\."
-        rf"{key}\[1\]: value {value[1]!r} must match regex",
+        rf"{key}\[1\]: Value `{value[1]}` must match regex",
     ):
         VariantPyProjectToml(
             {PYPROJECT_TOML_TOP_KEY: {PYPROJECT_TOML_DEFAULT_PRIO_KEY: {key: value}}}
@@ -169,7 +169,7 @@ def test_invalid_provider_namespace():
     with pytest.raises(
         ValidationError,
         match=rf"{PYPROJECT_TOML_TOP_KEY}\.{PYPROJECT_TOML_PROVIDER_DATA_KEY}"
-        r"\[0\]: value 'invalid namespace' must match regex",
+        r"\[0\]: Value `invalid namespace` must match regex",
     ):
         VariantPyProjectToml(
             {
@@ -217,7 +217,7 @@ def test_invalid_provider_requires():
     with pytest.raises(
         ValidationError,
         match=rf"{PYPROJECT_TOML_TOP_KEY}\.{PYPROJECT_TOML_PROVIDER_DATA_KEY}\.ns\."
-        rf"{PYPROJECT_TOML_PROVIDER_REQUIRES_KEY}\[1\]: value '' must match regex",
+        rf"{PYPROJECT_TOML_PROVIDER_REQUIRES_KEY}\[1\]: Value `` must match regex",
     ):
         VariantPyProjectToml(
             {
@@ -239,7 +239,7 @@ def test_invalid_provider_plugin_api():
     with pytest.raises(
         ValidationError,
         match=rf"{PYPROJECT_TOML_TOP_KEY}\.{PYPROJECT_TOML_PROVIDER_DATA_KEY}\.ns\."
-        rf"{PYPROJECT_TOML_PROVIDER_PLUGIN_API_KEY}: value 'frobnicate' must match "
+        rf"{PYPROJECT_TOML_PROVIDER_PLUGIN_API_KEY}: Value `frobnicate` must match "
         r"regex",
     ):
         VariantPyProjectToml(

--- a/tests/test_variants_json.py
+++ b/tests/test_variants_json.py
@@ -21,7 +21,7 @@ def test_validate_variants_json():
     with json_file.open() as f:
         data = json.load(f)
 
-    variants_json = VariantsJson.from_dict(data)
+    variants_json = VariantsJson(data)
     assert variants_json.variants == {
         "03e04d5e": VariantDescription(
             properties=[
@@ -175,7 +175,7 @@ def test_validate_variants_json():
 
 
 def test_validate_variants_json_empty():
-    assert VariantsJson.from_dict({"variants": {}}).variants == {}
+    assert VariantsJson({"variants": {}}).variants == {}
 
 
 @pytest.mark.parametrize(
@@ -196,4 +196,4 @@ def test_validate_variants_json_empty():
 )
 def test_validate_variants_json_incorrect_vhash(data: dict):
     with pytest.raises(ValidationError):
-        VariantsJson.from_dict(data)
+        VariantsJson(data)

--- a/variantlib/api.py
+++ b/variantlib/api.py
@@ -17,6 +17,7 @@ from variantlib.constants import METADATA_VARIANT_PROPERTY_HEADER
 from variantlib.constants import METADATA_VARIANT_PROVIDER_PLUGIN_API_HEADER
 from variantlib.constants import METADATA_VARIANT_PROVIDER_REQUIRES_HEADER
 from variantlib.constants import VARIANT_HASH_LEN
+from variantlib.dist_metadata import DistMetadata
 from variantlib.models.provider import ProviderConfig
 from variantlib.models.provider import VariantFeatureConfig
 from variantlib.models.variant import VariantDescription
@@ -26,6 +27,7 @@ from variantlib.models.variant import VariantValidationResult
 from variantlib.plugins.loader import BasePluginLoader
 from variantlib.plugins.loader import PluginLoader
 from variantlib.plugins.py_envs import AutoPythonEnv
+from variantlib.resolver.lib import filter_variants
 from variantlib.resolver.lib import sort_and_filter_supported_variants
 from variantlib.utils import aggregate_priority_lists
 from variantlib.variants_json import VariantsJson
@@ -33,6 +35,7 @@ from variantlib.variants_json import VariantsJson
 if TYPE_CHECKING:
     from email.message import Message
 
+    from variantlib.models.metadata import VariantMetadata
     from variantlib.pyproject_toml import VariantPyProjectToml
 
 
@@ -203,3 +206,68 @@ def set_variant_metadata(
             metadata[METADATA_VARIANT_DEFAULT_PRIO_PROPERTY_HEADER] = ", ".join(
                 x.to_str() for x in pyproject_toml.property_priorities
             )
+
+
+def check_variant_supported(
+    *,
+    vdesc: VariantDescription | None = None,
+    metadata: VariantMetadata,
+    use_auto_install: bool = True,
+    venv_path: str | pathlib.Path | None = None,
+    forbidden_namespaces: list[str] | None = None,
+    forbidden_features: list[str] | None = None,
+    forbidden_properties: list[str] | None = None,
+) -> bool:
+    """Check if variant description is supported
+
+    Returns True if the variant description is supported.
+
+    If `vdesc` is provided, it is tested. Otherwise, `metadata` must be
+    a `DistMetadata` and variant description is inferred from it.
+    """
+
+    if vdesc is None:
+        if metadata is None or not isinstance(metadata, DistMetadata):
+            raise TypeError("vdesc or metadata=DistMetadata(...) must be provided")
+        vdesc = metadata.variant_desc
+
+    venv_path = venv_path if venv_path is None else pathlib.Path(venv_path)
+
+    with (
+        AutoPythonEnv(
+            use_auto_install=use_auto_install, isolated=False, venv_path=venv_path
+        ) as python_ctx,
+        PluginLoader(variant_nfo=metadata, python_ctx=python_ctx) as plugin_loader,
+    ):
+        supported_vprops = list(
+            itertools.chain.from_iterable(
+                provider_cfg.to_list_of_properties()
+                for provider_cfg in plugin_loader.get_supported_configs().values()
+            )
+        )
+
+    _forbidden_features = (
+        None
+        if forbidden_features is None
+        else [VariantFeature.from_str(vfeat) for vfeat in forbidden_features]
+    )
+
+    _forbidden_properties = (
+        None
+        if forbidden_properties is None
+        else [VariantProperty.from_str(vprop) for vprop in forbidden_properties]
+    )
+
+    VariantConfiguration.get_config()
+
+    return bool(
+        list(
+            filter_variants(
+                vdescs=[vdesc],
+                allowed_properties=supported_vprops,
+                forbidden_namespaces=forbidden_namespaces,
+                forbidden_features=_forbidden_features,
+                forbidden_properties=_forbidden_properties,
+            )
+        )
+    )

--- a/variantlib/api.py
+++ b/variantlib/api.py
@@ -63,7 +63,7 @@ def get_variant_hashes_by_priority(
     forbidden_properties: list[str] | None = None,
 ) -> list[str]:
     supported_vprops = []
-    parsed_variants_json = VariantsJson.from_dict(variants_json)
+    parsed_variants_json = VariantsJson(variants_json)
 
     venv_path = venv_path if venv_path is None else pathlib.Path(venv_path)
 

--- a/variantlib/dist_metadata.py
+++ b/variantlib/dist_metadata.py
@@ -59,6 +59,12 @@ class DistMetadata(VariantMetadata):
             [VariantProperty.from_str(x) for x in variant_properties]
         )
 
+        if self.variant_desc.hexdigest != self.variant_hash:
+            raise ValidationError(
+                f"{METADATA_VARIANT_HASH_HEADER} specifies incorrect hash: "
+                f"{variant_hash!r}; expected: {self.variant_desc.hexdigest!r}"
+            )
+
         namespace_priorities = get_comma_sep(
             metadata.get(METADATA_VARIANT_DEFAULT_PRIO_NAMESPACE_HEADER, "")
         )

--- a/variantlib/dist_metadata.py
+++ b/variantlib/dist_metadata.py
@@ -1,0 +1,141 @@
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+from variantlib.constants import METADATA_VARIANT_DEFAULT_PRIO_FEATURE_HEADER
+from variantlib.constants import METADATA_VARIANT_DEFAULT_PRIO_NAMESPACE_HEADER
+from variantlib.constants import METADATA_VARIANT_DEFAULT_PRIO_PROPERTY_HEADER
+from variantlib.constants import METADATA_VARIANT_HASH_HEADER
+from variantlib.constants import METADATA_VARIANT_PROPERTY_HEADER
+from variantlib.constants import METADATA_VARIANT_PROVIDER_PLUGIN_API_HEADER
+from variantlib.constants import METADATA_VARIANT_PROVIDER_REQUIRES_HEADER
+from variantlib.constants import VALIDATION_FEATURE_REGEX
+from variantlib.constants import VALIDATION_METADATA_PROVIDER_PLUGIN_API_REGEX
+from variantlib.constants import VALIDATION_METADATA_PROVIDER_REQUIRES_REGEX
+from variantlib.constants import VALIDATION_NAMESPACE_REGEX
+from variantlib.constants import VALIDATION_PROPERTY_REGEX
+from variantlib.constants import VALIDATION_VARIANT_HASH_REGEX
+from variantlib.models.metadata import ProviderInfo
+from variantlib.models.metadata import VariantMetadata
+from variantlib.models.variant import VariantDescription
+from variantlib.models.variant import VariantFeature
+from variantlib.models.variant import VariantProperty
+from variantlib.validators import ValidationError
+from variantlib.validators import validate_list_matches_re
+from variantlib.validators import validate_matches_re
+
+if TYPE_CHECKING:
+    from email.message import Message
+
+
+def get_comma_sep(val: str) -> list[str]:
+    if not val.strip():
+        return []
+    return [x.strip() for x in val.split(",")]
+
+
+class DistMetadata(VariantMetadata):
+    variant_hash: str
+    variant_desc: VariantDescription
+
+    def __init__(self, metadata: Message) -> None:
+        # TODO: check for duplicate values
+
+        variant_hash = metadata.get(METADATA_VARIANT_HASH_HEADER, "")
+        validate_matches_re(
+            variant_hash,
+            VALIDATION_VARIANT_HASH_REGEX,
+            METADATA_VARIANT_HASH_HEADER,
+        )
+        self.variant_hash = variant_hash
+
+        variant_properties = metadata.get_all(METADATA_VARIANT_PROPERTY_HEADER, [])
+        validate_list_matches_re(
+            variant_properties,
+            VALIDATION_PROPERTY_REGEX,
+            METADATA_VARIANT_PROPERTY_HEADER,
+        )
+        self.variant_desc = VariantDescription(
+            [VariantProperty.from_str(x) for x in variant_properties]
+        )
+
+        namespace_priorities = get_comma_sep(
+            metadata.get(METADATA_VARIANT_DEFAULT_PRIO_NAMESPACE_HEADER, "")
+        )
+        validate_list_matches_re(
+            namespace_priorities,
+            VALIDATION_NAMESPACE_REGEX,
+            METADATA_VARIANT_DEFAULT_PRIO_NAMESPACE_HEADER,
+        )
+        self.namespace_priorities = namespace_priorities
+
+        feature_priorities = get_comma_sep(
+            metadata.get(METADATA_VARIANT_DEFAULT_PRIO_FEATURE_HEADER, "")
+        )
+        validate_list_matches_re(
+            feature_priorities,
+            VALIDATION_FEATURE_REGEX,
+            METADATA_VARIANT_DEFAULT_PRIO_FEATURE_HEADER,
+        )
+        self.feature_priorities = [
+            VariantFeature.from_str(x) for x in feature_priorities
+        ]
+
+        property_priorities = get_comma_sep(
+            metadata.get(METADATA_VARIANT_DEFAULT_PRIO_PROPERTY_HEADER, "")
+        )
+        validate_list_matches_re(
+            property_priorities,
+            VALIDATION_PROPERTY_REGEX,
+            METADATA_VARIANT_DEFAULT_PRIO_PROPERTY_HEADER,
+        )
+        self.property_priorities = [
+            VariantProperty.from_str(x) for x in property_priorities
+        ]
+
+        provider_requires: dict[str, list[str]] = {}
+        for require_tag in metadata.get_all(
+            METADATA_VARIANT_PROVIDER_REQUIRES_HEADER, []
+        ):
+            match = validate_matches_re(
+                require_tag,
+                VALIDATION_METADATA_PROVIDER_REQUIRES_REGEX,
+                METADATA_VARIANT_PROVIDER_REQUIRES_HEADER,
+            )
+            provider_requires.setdefault(match.group("namespace"), []).append(
+                match.group("requirement_str")
+            )
+
+        provider_plugin_api: dict[str, str] = {}
+        for plugin_api_tag in metadata.get_all(
+            METADATA_VARIANT_PROVIDER_PLUGIN_API_HEADER, []
+        ):
+            match = validate_matches_re(
+                plugin_api_tag,
+                VALIDATION_METADATA_PROVIDER_PLUGIN_API_REGEX,
+                METADATA_VARIANT_PROVIDER_PLUGIN_API_HEADER,
+            )
+            provider_plugin_api[match.group("namespace")] = match.group("plugin_api")
+
+        missing_plugin_api = set(provider_requires) - set(provider_plugin_api)
+        if missing_plugin_api:
+            raise ValidationError(
+                f"{METADATA_VARIANT_PROVIDER_REQUIRES_HEADER} includes namespaces that "
+                f"are not included in {METADATA_VARIANT_PROVIDER_PLUGIN_API_HEADER}: "
+                f"{missing_plugin_api}"
+            )
+
+        self.providers = {
+            namespace: ProviderInfo(
+                requires=provider_requires.get(namespace, []), plugin_api=plugin_api
+            )
+            for namespace, plugin_api in provider_plugin_api.items()
+        }
+
+        if set(self.namespace_priorities) != set(self.providers.keys()):
+            raise ValidationError(
+                f"{METADATA_VARIANT_DEFAULT_PRIO_NAMESPACE_HEADER} must specify "
+                f"the same namespaces as {METADATA_VARIANT_PROVIDER_PLUGIN_API_HEADER} "
+                f"key; currently: {set(self.namespace_priorities)} vs. "
+                f"{set(self.providers.keys())}"
+            )

--- a/variantlib/models/metadata.py
+++ b/variantlib/models/metadata.py
@@ -1,0 +1,22 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from variantlib.models.variant import VariantFeature
+    from variantlib.models.variant import VariantProperty
+
+
+@dataclass
+class ProviderInfo:
+    requires: list[str]
+    plugin_api: str
+
+
+@dataclass
+class VariantMetadata:
+    namespace_priorities: list[str]
+    feature_priorities: list[VariantFeature]
+    property_priorities: list[VariantProperty]
+    providers: dict[str, ProviderInfo]

--- a/variantlib/models/metadata.py
+++ b/variantlib/models/metadata.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 from dataclasses import dataclass
+from dataclasses import field
 from typing import TYPE_CHECKING
 
 if TYPE_CHECKING:
@@ -10,13 +11,13 @@ if TYPE_CHECKING:
 
 @dataclass
 class ProviderInfo:
-    requires: list[str]
     plugin_api: str
+    requires: list[str] = field(default_factory=list)
 
 
 @dataclass
 class VariantMetadata:
-    namespace_priorities: list[str]
-    feature_priorities: list[VariantFeature]
-    property_priorities: list[VariantProperty]
-    providers: dict[str, ProviderInfo]
+    namespace_priorities: list[str] = field(default_factory=list)
+    feature_priorities: list[VariantFeature] = field(default_factory=list)
+    property_priorities: list[VariantProperty] = field(default_factory=list)
+    providers: dict[str, ProviderInfo] = field(default_factory=dict)

--- a/variantlib/plugins/loader.py
+++ b/variantlib/plugins/loader.py
@@ -31,8 +31,8 @@ from variantlib.validators import validate_type
 if TYPE_CHECKING:
     from collections.abc import Callable
 
+    from variantlib.models.metadata import VariantMetadata
     from variantlib.models.variant import VariantDescription
-    from variantlib.variants_json import VariantsJson
 
 if sys.version_info >= (3, 11):
     from typing import Self
@@ -292,11 +292,11 @@ class BasePluginLoader:
 
 
 class PluginLoader(BasePluginLoader):
-    _variant_nfo: VariantsJson
+    _variant_nfo: VariantMetadata
 
     def __init__(
         self,
-        variant_nfo: VariantsJson,
+        variant_nfo: VariantMetadata,
         python_ctx: BasePythonEnv | None = None,
     ) -> None:
         self._variant_nfo = variant_nfo

--- a/variantlib/pyproject_toml.py
+++ b/variantlib/pyproject_toml.py
@@ -1,7 +1,6 @@
 from __future__ import annotations
 
 import sys
-from dataclasses import dataclass
 from typing import TYPE_CHECKING
 from typing import Any
 
@@ -18,6 +17,8 @@ from variantlib.constants import VALIDATION_NAMESPACE_REGEX
 from variantlib.constants import VALIDATION_PROPERTY_REGEX
 from variantlib.constants import VALIDATION_PROVIDER_PLUGIN_API_REGEX
 from variantlib.constants import VALIDATION_PROVIDER_REQUIRES_REGEX
+from variantlib.models.metadata import ProviderInfo
+from variantlib.models.metadata import VariantMetadata
 from variantlib.models.variant import VariantFeature
 from variantlib.models.variant import VariantProperty
 from variantlib.validators import KeyTrackingValidator
@@ -35,18 +36,7 @@ else:
     from typing_extensions import Self
 
 
-@dataclass
-class ProviderInfo:
-    requires: list[str]
-    plugin_api: str
-
-
-class VariantPyProjectToml:
-    namespace_priorities: list[str]
-    feature_priorities: list[VariantFeature]
-    property_priorities: list[VariantProperty]
-    providers: dict[str, ProviderInfo]
-
+class VariantPyProjectToml(VariantMetadata):
     def __init__(self, toml_data: dict) -> None:
         """Init from pre-read ``pyproject.toml`` data"""
         self._process(toml_data.get(PYPROJECT_TOML_TOP_KEY, {}))

--- a/variantlib/pyproject_toml.py
+++ b/variantlib/pyproject_toml.py
@@ -87,7 +87,7 @@ class VariantPyProjectToml(VariantMetadata):
                     ) as provider_plugin_api:
                         validator.matches_re(VALIDATION_PROVIDER_PLUGIN_API_REGEX)
                     self.providers[namespace] = ProviderInfo(
-                        provider_requires, provider_plugin_api
+                        requires=provider_requires, plugin_api=provider_plugin_api
                     )
 
         if set(self.namespace_priorities) != set(self.providers.keys()):

--- a/variantlib/variants_json.py
+++ b/variantlib/variants_json.py
@@ -1,7 +1,5 @@
 from __future__ import annotations
 
-import sys
-from dataclasses import dataclass
 from typing import Any
 
 from variantlib.constants import VALIDATION_FEATURE_REGEX
@@ -18,47 +16,29 @@ from variantlib.constants import VARIANTS_JSON_PROVIDER_DATA_KEY
 from variantlib.constants import VARIANTS_JSON_PROVIDER_PLUGIN_API_KEY
 from variantlib.constants import VARIANTS_JSON_PROVIDER_REQUIRES_KEY
 from variantlib.constants import VARIANTS_JSON_VARIANT_DATA_KEY
+from variantlib.models.metadata import ProviderInfo
+from variantlib.models.metadata import VariantMetadata
 from variantlib.models.variant import VariantDescription
 from variantlib.models.variant import VariantFeature
 from variantlib.models.variant import VariantProperty
-from variantlib.pyproject_toml import ProviderInfo
 from variantlib.validators import KeyTrackingValidator
 from variantlib.validators import ValidationError
 
-if sys.version_info >= (3, 11):
-    from typing import Self
-else:
-    from typing_extensions import Self
 
-
-@dataclass(frozen=True)
-class VariantsJson:
-    namespace_priorities: list[str]
-    feature_priorities: list[VariantFeature]
-    property_priorities: list[VariantProperty]
-    providers: dict[str, ProviderInfo]
+class VariantsJson(VariantMetadata):
     variants: dict[str, VariantDescription]
 
-    @classmethod
-    def from_dict(cls, variants_json: dict) -> Self:
+    def __init__(self, variants_json: dict) -> None:
         """Init from pre-read ``variants.json`` data"""
-        return cls(**cls._process(variants_json))
+        self._process(variants_json)
 
-    @classmethod
-    def _process(cls, variant_table: dict) -> dict:
+    def _process(self, variant_table: dict) -> None:
         validator = KeyTrackingValidator(None, variant_table)
-
-        result: dict[str, Any] = {
-            "namespace_priorities": [],
-            "feature_priorities": [],
-            "property_priorities": [],
-            "providers": {},
-            "variants": {},
-        }
 
         with validator.get(VARIANTS_JSON_VARIANT_DATA_KEY, dict[str, dict]) as variants:
             validator.list_matches_re(VALIDATION_VARIANT_HASH_REGEX)
             variant_hashes = list(variants.keys())
+            self.variants = {}
             for variant_hash in variant_hashes:
                 with validator.get(
                     variant_hash, dict[str, dict], ignore_subkeys=True
@@ -69,26 +49,26 @@ class VariantsJson:
                             f"Variant hash mismatch: {variant_hash=!r} != "
                             f"{vdesc.hexdigest=!r}"
                         )
-                    result["variants"][variant_hash] = vdesc
+                    self.variants[variant_hash] = vdesc
 
         with validator.get(VARIANTS_JSON_DEFAULT_PRIO_KEY, dict[str, Any], {}):
             with validator.get(
                 VARIANTS_JSON_NAMESPACE_KEY, list[str], []
             ) as namespace_priorities:
                 validator.list_matches_re(VALIDATION_NAMESPACE_REGEX)
-                result["namespace_priorities"] = namespace_priorities
+                self.namespace_priorities = namespace_priorities
             with validator.get(
                 VARIANTS_JSON_FEATURE_KEY, list[str], []
             ) as feature_priorities:
                 validator.list_matches_re(VALIDATION_FEATURE_REGEX)
-                result["feature_priorities"] = [
+                self.feature_priorities = [
                     VariantFeature.from_str(x) for x in feature_priorities
                 ]
             with validator.get(
                 VARIANTS_JSON_PROPERTY_KEY, list[str], []
             ) as property_priorities:
                 validator.list_matches_re(VALIDATION_PROPERTY_REGEX)
-                result["property_priorities"] = [
+                self.property_priorities = [
                     VariantProperty.from_str(x) for x in property_priorities
                 ]
 
@@ -97,7 +77,7 @@ class VariantsJson:
         ) as providers:
             validator.list_matches_re(VALIDATION_NAMESPACE_REGEX)
             namespaces = list(providers.keys())
-            result["providers"] = {}
+            self.providers = {}
             for namespace in namespaces:
                 with validator.get(namespace, dict[str, Any], {}):
                     with validator.get(
@@ -108,17 +88,15 @@ class VariantsJson:
                         VARIANTS_JSON_PROVIDER_PLUGIN_API_KEY, str, None
                     ) as provider_plugin_api:
                         validator.matches_re(VALIDATION_PROVIDER_PLUGIN_API_REGEX)
-                    result["providers"][namespace] = ProviderInfo(
+                    self.providers[namespace] = ProviderInfo(
                         provider_requires, provider_plugin_api
                     )
 
-        if set(result["namespace_priorities"]) != set(result["providers"].keys()):
+        if set(self.namespace_priorities) != set(self.providers.keys()):
             raise ValidationError(
                 f"{VARIANTS_JSON_DEFAULT_PRIO_KEY}.{VARIANTS_JSON_NAMESPACE_KEY} "
                 "must specify the same namespaces as "
                 f"{VARIANTS_JSON_PROVIDER_DATA_KEY} object; currently: "
-                f"{set(result['namespace_priorities'])} vs. "
-                f"{set(result['providers'].keys())}"
+                f"{set(self.namespace_priorities)} vs. "
+                f"{set(self.providers.keys())}"
             )
-
-        return result

--- a/variantlib/variants_json.py
+++ b/variantlib/variants_json.py
@@ -89,7 +89,7 @@ class VariantsJson(VariantMetadata):
                     ) as provider_plugin_api:
                         validator.matches_re(VALIDATION_PROVIDER_PLUGIN_API_REGEX)
                     self.providers[namespace] = ProviderInfo(
-                        provider_requires, provider_plugin_api
+                        requires=provider_requires, plugin_api=provider_plugin_api
                     )
 
         if set(self.namespace_priorities) != set(self.providers.keys()):


### PR DESCRIPTION
Quite a big and not yet complete: I still need to add more checks and tests.

1. With this change, we have three metadata classes:
    - `DistMetadata` for distribution `METADATA` files
    - `VariantPyProjectToml` for `pyproject.toml`
    - `VariantsJson` for `variants.json`
2. All of them derive from shared `VariantMetadata` model that covers the common bits, plus have their own extra fields.
3. <del>`PluginLoader` now has a constructor that accepts any `VariantMetadata` subclass and loads plugins from it.</del>
4. <del>For `get_variant_hashes_by_priority()`, `plugin_loader` is now optional, so you can either pass your own or let it load plugins from `variants.json`. This is similar to #86 but it preserves the ability to provide custom loader, which will probably be useful for pip isolated envs.</del>
5. There is a new `check_variant_supported()` function that can be used to check whether a single variant description can be installed — now used by pip when installing local files.

The classes are pretty robust now, and I think we will use them in the future to reimplement some of the commands that now inline metadata reading and writing.