### PR TITLE
Fix CI for make-variant and add longer option support

### DIFF
--- a/variantlib/commands/make_variant.py
+++ b/variantlib/commands/make_variant.py
@@ -2,7 +2,6 @@ from __future__ import annotations
 
 import argparse
 import base64
-import contextlib
 import email.parser
 import email.policy
 import hashlib
@@ -13,14 +12,13 @@ import zipfile
 
 from variantlib import __package_name__
 from variantlib.api import VariantDescription
+from variantlib.api import VariantFeature
 from variantlib.api import VariantProperty
 from variantlib.api import set_variant_metadata
 from variantlib.api import validate_variant
-from variantlib.constants import VALIDATION_FEATURE_REGEX
 from variantlib.constants import VALIDATION_METADATA_PROVIDER_PLUGIN_API_REGEX
 from variantlib.constants import VALIDATION_METADATA_PROVIDER_REQUIRES_REGEX
 from variantlib.constants import VALIDATION_NAMESPACE_REGEX
-from variantlib.constants import VALIDATION_PROPERTY_REGEX
 from variantlib.constants import VALIDATION_WHEEL_NAME_REGEX
 from variantlib.errors import ValidationError
 from variantlib.plugins.loader import ManualPluginLoader
@@ -89,22 +87,26 @@ def make_variant(args: list[str]) -> None:
 
     parser.add_argument(
         "--default-namespace-priorities",
-        type=str,
-        default=None,
+        type=lambda prios: prios.split(","),
+        default=[],
         help="Comma separated list of namespace priority",
     )
 
     parser.add_argument(
         "--default-feature-priorities",
-        type=str,
-        default=None,
+        type=lambda prios: [
+            VariantFeature.from_str(vfeat) for vfeat in prios.split(",")
+        ],
+        default=[],
         help="Comma separated list of feature priority",
     )
 
     parser.add_argument(
         "--default-property-priorities",
-        type=str,
-        default=None,
+        type=lambda prios: [
+            VariantProperty.from_str(vprop) for vprop in prios.split(",")
+        ],
+        default=[],
         help="Comma separated list of property priority",
     )
 
@@ -128,28 +130,12 @@ def make_variant(args: list[str]) -> None:
     parsed_args = parser.parse_args(args)
 
     pyproj_toml = VariantPyProjectToml(toml_data={})
-
-    with contextlib.suppress(AttributeError):
-        pyproj_toml.namespace_priorities = (
-            parsed_args.default_namespace_priorities.split(",")
-        )
-        for ns in pyproj_toml.namespace_priorities:
-            if VALIDATION_NAMESPACE_REGEX.fullmatch(ns) is None:
-                raise ValueError(f"The following namespace is invalid: `{ns}`")
-    with contextlib.suppress(AttributeError):
-        pyproj_toml.feature_priorities = parsed_args.default_feature_priorities.split(
-            ","
-        )
-        for vfeat in pyproj_toml.feature_priorities:
-            if VALIDATION_FEATURE_REGEX.fullmatch(vfeat) is None:
-                raise ValueError(f"The following feature is invalid: `{vfeat}`")
-    with contextlib.suppress(AttributeError):
-        pyproj_toml.property_priorities = parsed_args.default_property_priorities.split(
-            ","
-        )
-        for vprop in pyproj_toml.property_priorities:
-            if VALIDATION_PROPERTY_REGEX.fullmatch(vprop) is None:
-                raise ValueError(f"The following feature is invalid: `{vprop}`")
+    pyproj_toml.namespace_priorities = parsed_args.default_namespace_priorities
+    for ns in pyproj_toml.namespace_priorities:
+        if VALIDATION_NAMESPACE_REGEX.fullmatch(ns) is None:
+            raise ValueError(f"The following namespace is invalid: `{ns}`")
+    pyproj_toml.feature_priorities = parsed_args.default_feature_priorities
+    pyproj_toml.property_priorities = parsed_args.default_property_priorities
 
     for provider_api in parsed_args.provider_api:
         if (

--- a/variantlib/commands/make_variant.py
+++ b/variantlib/commands/make_variant.py
@@ -88,28 +88,28 @@ def make_variant(args: list[str]) -> None:
     )
 
     parser.add_argument(
-        "--default-namespace-prio",
+        "--default-namespace-priorities",
         type=str,
         default=None,
         help="Comma separated list of namespace priority",
     )
 
     parser.add_argument(
-        "--default-feature-prio",
+        "--default-feature-priorities",
         type=str,
         default=None,
         help="Comma separated list of feature priority",
     )
 
     parser.add_argument(
-        "--default-property-prio",
+        "--default-property-priorities",
         type=str,
         default=None,
         help="Comma separated list of property priority",
     )
 
     parser.add_argument(
-        "--provider-req",
+        "--provider-requires",
         action="append",
         default=[],
         help=(
@@ -130,17 +130,23 @@ def make_variant(args: list[str]) -> None:
     pyproj_toml = VariantPyProjectToml(toml_data={})
 
     with contextlib.suppress(AttributeError):
-        pyproj_toml.namespace_priorities = parsed_args.default_namespace_prio.split(",")
+        pyproj_toml.namespace_priorities = (
+            parsed_args.default_namespace_priorities.split(",")
+        )
         for ns in pyproj_toml.namespace_priorities:
             if VALIDATION_NAMESPACE_REGEX.fullmatch(ns) is None:
                 raise ValueError(f"The following namespace is invalid: `{ns}`")
     with contextlib.suppress(AttributeError):
-        pyproj_toml.feature_priorities = parsed_args.default_feature_prio.split(",")
+        pyproj_toml.feature_priorities = parsed_args.default_feature_priorities.split(
+            ","
+        )
         for vfeat in pyproj_toml.feature_priorities:
             if VALIDATION_FEATURE_REGEX.fullmatch(vfeat) is None:
                 raise ValueError(f"The following feature is invalid: `{vfeat}`")
     with contextlib.suppress(AttributeError):
-        pyproj_toml.property_priorities = parsed_args.default_property_prio.split(",")
+        pyproj_toml.property_priorities = parsed_args.default_property_priorities.split(
+            ","
+        )
         for vprop in pyproj_toml.property_priorities:
             if VALIDATION_PROPERTY_REGEX.fullmatch(vprop) is None:
                 raise ValueError(f"The following feature is invalid: `{vprop}`")
@@ -164,7 +170,7 @@ def make_variant(args: list[str]) -> None:
             plugin_api=match.group("plugin_api"),
         )
 
-    for provider_req in parsed_args.provider_req:
+    for provider_req in parsed_args.provider_requires:
         if (
             match := VALIDATION_METADATA_PROVIDER_REQUIRES_REGEX.fullmatch(provider_req)
         ) is None:

--- a/variantlib/commands/make_variant.py
+++ b/variantlib/commands/make_variant.py
@@ -211,10 +211,11 @@ def make_variant(args: list[str]) -> None:
 def _make_variant(
     input_filepath: pathlib.Path,
     output_directory: pathlib.Path,
+    *,
     is_null_variant: bool,
     properties: list[VariantProperty],
     validate_properties: bool = True,
-    pyproject_toml: VariantPyProjectToml | None = None,
+    pyproject_toml: VariantPyProjectToml,
 ) -> None:
     # Input Validation
     if not input_filepath.is_file():


### PR DESCRIPTION
1. Fix validation of wrong value in `make-variant`.
2. Fix type hints to get green CI.
3. Support longer options (matching the keys) in addition to the contractions.