### PR TITLE
Restore entry points based loader, and use it for CLI commands

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,8 +1,3 @@
-from collections.abc import Callable
-from collections.abc import Generator
-from contextlib import _GeneratorContextManager
-from contextlib import contextmanager
-
 import pytest
 
 from variantlib.plugins.loader import BasePluginLoader
@@ -19,14 +14,10 @@ def mocked_plugin_apis() -> list[str]:
 
 
 @pytest.fixture(scope="session")
-def mocked_plugin_loader_ctx(
+def mocked_plugin_loader(
     mocked_plugin_apis: list[str],
-) -> Callable[[], _GeneratorContextManager[BasePluginLoader]]:
-    @contextmanager
-    def ctx() -> Generator[BasePluginLoader]:
-        loader = ManualPluginLoader()
-        for plugin_api in mocked_plugin_apis:
-            loader.load_plugin(plugin_api)
-        yield loader
-
-    return ctx
+) -> BasePluginLoader:
+    loader = ManualPluginLoader()
+    for plugin_api in mocked_plugin_apis:
+        loader.load_plugin(plugin_api)
+    return loader

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -5,8 +5,8 @@ from contextlib import contextmanager
 
 import pytest
 
-from variantlib.plugins.loader import CLIPluginLoader
-from variantlib.plugins.py_envs import ExternalNonIsolatedPythonEnv
+from variantlib.plugins.loader import BasePluginLoader
+from variantlib.plugins.loader import ManualPluginLoader
 
 
 @pytest.fixture(scope="session")
@@ -21,13 +21,12 @@ def mocked_plugin_apis() -> list[str]:
 @pytest.fixture(scope="session")
 def mocked_plugin_loader_ctx(
     mocked_plugin_apis: list[str],
-) -> Callable[[], _GeneratorContextManager[CLIPluginLoader]]:
+) -> Callable[[], _GeneratorContextManager[BasePluginLoader]]:
     @contextmanager
-    def ctx() -> Generator[CLIPluginLoader]:
-        with ExternalNonIsolatedPythonEnv() as py_ctx:  # noqa: SIM117
-            with CLIPluginLoader(
-                plugin_apis=mocked_plugin_apis, python_ctx=py_ctx
-            ) as loader:
-                yield loader
+    def ctx() -> Generator[BasePluginLoader]:
+        loader = ManualPluginLoader()
+        for plugin_api in mocked_plugin_apis:
+            loader.load_plugin(plugin_api)
+        yield loader
 
     return ctx

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -51,7 +51,7 @@ if TYPE_CHECKING:
     from collections.abc import Generator
     from contextlib import _GeneratorContextManager
 
-    from variantlib.plugins.loader import CLIPluginLoader
+    from variantlib.plugins.loader import BasePluginLoader
 
 
 def test_api_accessible():
@@ -65,7 +65,7 @@ def test_api_accessible():
 
 @pytest.fixture
 def configs(
-    mocked_plugin_loader_ctx: Callable[[], _GeneratorContextManager[CLIPluginLoader]],
+    mocked_plugin_loader_ctx: Callable[[], _GeneratorContextManager[BasePluginLoader]],
 ):
     with mocked_plugin_loader_ctx() as loader:
         return list(loader.get_supported_configs().values())

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -47,9 +47,7 @@ from variantlib.plugins.loader import ManualPluginLoader
 from variantlib.pyproject_toml import VariantPyProjectToml
 
 if TYPE_CHECKING:
-    from collections.abc import Callable
     from collections.abc import Generator
-    from contextlib import _GeneratorContextManager
 
     from variantlib.plugins.loader import BasePluginLoader
 
@@ -65,10 +63,9 @@ def test_api_accessible():
 
 @pytest.fixture
 def configs(
-    mocked_plugin_loader_ctx: Callable[[], _GeneratorContextManager[BasePluginLoader]],
+    mocked_plugin_loader: BasePluginLoader,
 ):
-    with mocked_plugin_loader_ctx() as loader:
-        return list(loader.get_supported_configs().values())
+    return list(mocked_plugin_loader.get_supported_configs().values())
 
 
 def test_get_variant_hashes_by_priority_roundtrip(

--- a/tests/test_plugins.py
+++ b/tests/test_plugins.py
@@ -341,6 +341,19 @@ def test_load_plugin():
     assert "second_namespace" in loader.plugins
 
 
+def test_manual_plugin_loader_as_context_manager():
+    with ManualPluginLoader() as loader:
+        loader.load_plugin("tests.mocked_plugins:IndirectPath.MoreIndirection.plugin_a")
+        assert "test_namespace" in loader.plugins
+        assert "second_namespace" not in loader.plugins
+
+        loader.load_plugin("tests.mocked_plugins:IndirectPath.MoreIndirection.plugin_b")
+        assert "test_namespace" in loader.plugins
+        assert "second_namespace" in loader.plugins
+
+    assert not loader.plugins
+
+
 def test_load_plugin_invalid_arg():
     with pytest.raises(ValidationError):
         ManualPluginLoader().load_plugin("tests.mocked_plugins")

--- a/tests/test_plugins.py
+++ b/tests/test_plugins.py
@@ -5,7 +5,6 @@ import re
 import sys
 from dataclasses import dataclass
 from email import message_from_string
-from typing import TYPE_CHECKING
 from typing import Any
 
 import pytest
@@ -35,9 +34,6 @@ if sys.version_info >= (3, 11):
 else:
     import tomli as tomllib
 
-if TYPE_CHECKING:
-    from collections.abc import Callable
-    from contextlib import _GeneratorContextManager
 
 RANDOM_STUFF = 123
 
@@ -72,54 +68,52 @@ class ExceptionTestingPlugin(PluginType):
 
 
 def test_get_all_configs(
-    mocked_plugin_loader_ctx: Callable[[], _GeneratorContextManager[BasePluginLoader]],
+    mocked_plugin_loader: BasePluginLoader,
 ):
-    with mocked_plugin_loader_ctx() as loader:
-        assert loader.get_all_configs() == {
-            "incompatible_namespace": ProviderConfig(
-                namespace="incompatible_namespace",
-                configs=[
-                    VariantFeatureConfig("flag1", ["on"]),
-                    VariantFeatureConfig("flag2", ["on"]),
-                    VariantFeatureConfig("flag3", ["on"]),
-                    VariantFeatureConfig("flag4", ["on"]),
-                ],
-            ),
-            "second_namespace": ProviderConfig(
-                namespace="second_namespace",
-                configs=[
-                    VariantFeatureConfig("name3", ["val3a", "val3b", "val3c"]),
-                ],
-            ),
-            "test_namespace": ProviderConfig(
-                namespace="test_namespace",
-                configs=[
-                    VariantFeatureConfig("name1", ["val1a", "val1b", "val1c", "val1d"]),
-                    VariantFeatureConfig("name2", ["val2a", "val2b", "val2c"]),
-                ],
-            ),
-        }
+    assert mocked_plugin_loader.get_all_configs() == {
+        "incompatible_namespace": ProviderConfig(
+            namespace="incompatible_namespace",
+            configs=[
+                VariantFeatureConfig("flag1", ["on"]),
+                VariantFeatureConfig("flag2", ["on"]),
+                VariantFeatureConfig("flag3", ["on"]),
+                VariantFeatureConfig("flag4", ["on"]),
+            ],
+        ),
+        "second_namespace": ProviderConfig(
+            namespace="second_namespace",
+            configs=[
+                VariantFeatureConfig("name3", ["val3a", "val3b", "val3c"]),
+            ],
+        ),
+        "test_namespace": ProviderConfig(
+            namespace="test_namespace",
+            configs=[
+                VariantFeatureConfig("name1", ["val1a", "val1b", "val1c", "val1d"]),
+                VariantFeatureConfig("name2", ["val2a", "val2b", "val2c"]),
+            ],
+        ),
+    }
 
 
 def test_get_supported_configs(
-    mocked_plugin_loader_ctx: Callable[[], _GeneratorContextManager[BasePluginLoader]],
+    mocked_plugin_loader: BasePluginLoader,
 ):
-    with mocked_plugin_loader_ctx() as loader:
-        assert loader.get_supported_configs() == {
-            "second_namespace": ProviderConfig(
-                namespace="second_namespace",
-                configs=[
-                    VariantFeatureConfig("name3", ["val3a"]),
-                ],
-            ),
-            "test_namespace": ProviderConfig(
-                namespace="test_namespace",
-                configs=[
-                    VariantFeatureConfig("name1", ["val1a", "val1b"]),
-                    VariantFeatureConfig("name2", ["val2a", "val2b", "val2c"]),
-                ],
-            ),
-        }
+    assert mocked_plugin_loader.get_supported_configs() == {
+        "second_namespace": ProviderConfig(
+            namespace="second_namespace",
+            configs=[
+                VariantFeatureConfig("name3", ["val3a"]),
+            ],
+        ),
+        "test_namespace": ProviderConfig(
+            namespace="test_namespace",
+            configs=[
+                VariantFeatureConfig("name1", ["val1a", "val1b"]),
+                VariantFeatureConfig("name2", ["val2a", "val2b", "val2c"]),
+            ],
+        ),
+    }
 
 
 def test_manual_loading(mocked_plugin_apis: list[str]):
@@ -282,7 +276,7 @@ def test_namespace_instantiation_returns_incorrect_type(cls: type, mocker):
 
 
 def test_get_build_setup(
-    mocked_plugin_loader_ctx: Callable[[], _GeneratorContextManager[BasePluginLoader]],
+    mocked_plugin_loader: BasePluginLoader,
 ):
     variant_desc = VariantDescription(
         [
@@ -293,16 +287,15 @@ def test_get_build_setup(
         ]
     )
 
-    with mocked_plugin_loader_ctx() as loader:
-        assert loader.get_build_setup(variant_desc) == {
-            "cflags": ["-mflag1", "-mflag4", "-march=val1b"],
-            "cxxflags": ["-mflag1", "-mflag4", "-march=val1b"],
-            "ldflags": ["-Wl,--test-flag"],
-        }
+    assert mocked_plugin_loader.get_build_setup(variant_desc) == {
+        "cflags": ["-mflag1", "-mflag4", "-march=val1b"],
+        "cxxflags": ["-mflag1", "-mflag4", "-march=val1b"],
+        "ldflags": ["-Wl,--test-flag"],
+    }
 
 
 def test_get_build_setup_missing_plugin(
-    mocked_plugin_loader_ctx: Callable[[], _GeneratorContextManager[BasePluginLoader]],
+    mocked_plugin_loader: BasePluginLoader,
 ):
     variant_desc = VariantDescription(
         [
@@ -311,23 +304,21 @@ def test_get_build_setup_missing_plugin(
         ]
     )
 
-    with mocked_plugin_loader_ctx() as loader:  # noqa: SIM117
-        with pytest.raises(
-            PluginMissingError,
-            match=r"No plugin found for namespace missing_plugin",
-        ):
-            assert loader.get_build_setup(variant_desc)
+    with pytest.raises(
+        PluginMissingError,
+        match=r"No plugin found for namespace missing_plugin",
+    ):
+        assert mocked_plugin_loader.get_build_setup(variant_desc)
 
 
 def test_namespaces(
-    mocked_plugin_loader_ctx: Callable[[], _GeneratorContextManager[BasePluginLoader]],
+    mocked_plugin_loader: BasePluginLoader,
 ):
-    with mocked_plugin_loader_ctx() as loader:
-        assert loader.namespaces == [
-            "test_namespace",
-            "second_namespace",
-            "incompatible_namespace",
-        ]
+    assert mocked_plugin_loader.namespaces == [
+        "test_namespace",
+        "second_namespace",
+        "incompatible_namespace",
+    ]
 
 
 def test_load_plugin():

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -10,19 +10,15 @@ from variantlib.api import VariantProperty
 from variantlib.utils import aggregate_priority_lists
 
 if TYPE_CHECKING:
-    from collections.abc import Callable
-    from contextlib import _GeneratorContextManager
-
     from variantlib.models.provider import ProviderConfig
     from variantlib.plugins.loader import BasePluginLoader
 
 
 @pytest.fixture
 def configs(
-    mocked_plugin_loader_ctx: Callable[[], _GeneratorContextManager[BasePluginLoader]],
+    mocked_plugin_loader: BasePluginLoader,
 ) -> list[ProviderConfig]:
-    with mocked_plugin_loader_ctx() as loader:
-        return list(loader.get_supported_configs().values())
+    return list(mocked_plugin_loader.get_supported_configs().values())
 
 
 def test_get_combinations(configs):

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -14,12 +14,12 @@ if TYPE_CHECKING:
     from contextlib import _GeneratorContextManager
 
     from variantlib.models.provider import ProviderConfig
-    from variantlib.plugins.loader import CLIPluginLoader
+    from variantlib.plugins.loader import BasePluginLoader
 
 
 @pytest.fixture
 def configs(
-    mocked_plugin_loader_ctx: Callable[[], _GeneratorContextManager[CLIPluginLoader]],
+    mocked_plugin_loader_ctx: Callable[[], _GeneratorContextManager[BasePluginLoader]],
 ) -> list[ProviderConfig]:
     with mocked_plugin_loader_ctx() as loader:
         return list(loader.get_supported_configs().values())

--- a/variantlib/api.py
+++ b/variantlib/api.py
@@ -24,7 +24,6 @@ from variantlib.models.variant import VariantDescription
 from variantlib.models.variant import VariantFeature
 from variantlib.models.variant import VariantProperty
 from variantlib.models.variant import VariantValidationResult
-from variantlib.plugins.loader import BasePluginLoader
 from variantlib.plugins.loader import PluginLoader
 from variantlib.plugins.py_envs import AutoPythonEnv
 from variantlib.resolver.lib import filter_variants
@@ -36,6 +35,7 @@ if TYPE_CHECKING:
     from email.message import Message
 
     from variantlib.models.metadata import VariantMetadata
+    from variantlib.plugins.loader import BasePluginLoader
 
 
 logger = logging.getLogger(__name__)

--- a/variantlib/commands/plugins/get_all_configs.py
+++ b/variantlib/commands/plugins/get_all_configs.py
@@ -8,12 +8,12 @@ from variantlib import __package_name__
 from variantlib.commands.plugins._display_configs import display_configs
 
 if TYPE_CHECKING:
-    from variantlib.loader import PluginLoader
+    from variantlib.loader import BasePluginLoader
 
 logger = logging.getLogger(__name__)
 
 
-def get_all_configs(args: list[str], plugin_loader: PluginLoader) -> None:
+def get_all_configs(args: list[str], plugin_loader: BasePluginLoader) -> None:
     parser = argparse.ArgumentParser(
         prog=f"{__package_name__} plugins get-all-configs",
         description="CLI interface to get all valid configs",

--- a/variantlib/commands/plugins/get_supported_configs.py
+++ b/variantlib/commands/plugins/get_supported_configs.py
@@ -8,12 +8,12 @@ from variantlib import __package_name__
 from variantlib.commands.plugins._display_configs import display_configs
 
 if TYPE_CHECKING:
-    from variantlib.plugins.loader import PluginLoader
+    from variantlib.plugins.loader import BasePluginLoader
 
 logger = logging.getLogger(__name__)
 
 
-def get_supported_configs(args: list[str], plugin_loader: PluginLoader) -> None:
+def get_supported_configs(args: list[str], plugin_loader: BasePluginLoader) -> None:
     parser = argparse.ArgumentParser(
         prog=f"{__package_name__} plugins get-supported-configs",
         description="CLI interface to get all supported configs on the machine",

--- a/variantlib/commands/plugins/list_plugins.py
+++ b/variantlib/commands/plugins/list_plugins.py
@@ -8,12 +8,12 @@ from typing import TYPE_CHECKING
 from variantlib import __package_name__
 
 if TYPE_CHECKING:
-    from variantlib.plugins.loader import PluginLoader
+    from variantlib.plugins.loader import BasePluginLoader
 
 logger = logging.getLogger(__name__)
 
 
-def list_plugins(args: list[str], plugin_loader: PluginLoader) -> None:
+def list_plugins(args: list[str], plugin_loader: BasePluginLoader) -> None:
     parser = argparse.ArgumentParser(
         prog=f"{__package_name__} plugins list-plugins",
         description="CLI interface to list plugins",

--- a/variantlib/plugins/loader.py
+++ b/variantlib/plugins/loader.py
@@ -54,6 +54,7 @@ class BasePluginLoader:
     """Load and query plugins"""
 
     _plugins: dict[str, PluginType] | None = None
+    _plugin_api_values: dict[str, str] | None = None
     _python_ctx: BasePythonEnv | None = None
 
     def __init__(self, python_ctx: BasePythonEnv | None = None) -> None:
@@ -68,6 +69,7 @@ class BasePluginLoader:
         return self
 
     def __exit__(self, *args: object) -> None:
+        self._plugin_api_values = None
         self._plugins = None
 
         if self._python_ctx is None:
@@ -169,6 +171,8 @@ class BasePluginLoader:
 
         if self._plugins is None:
             self._plugins = {}
+        if self._plugin_api_values is None:
+            self._plugin_api_values = {}
 
         if plugin_instance.namespace in self._plugins:
             raise RuntimeError(
@@ -177,6 +181,7 @@ class BasePluginLoader:
             )
 
         self._plugins[plugin_instance.namespace] = plugin_instance
+        self._plugin_api_values[plugin_instance.namespace] = plugin_api
 
     @abstractmethod
     def _load_all_plugins(self) -> None: ...
@@ -295,6 +300,13 @@ class BasePluginLoader:
         if self._plugins is None:
             raise RuntimeError("You can not access plugins outside of a python context")
         return self._plugins
+
+    @property
+    def plugin_api_values(self) -> dict[str, str]:
+        if self._plugins is None:
+            raise RuntimeError("You can not access plugins outside of a python context")
+        assert self._plugin_api_values is not None
+        return self._plugin_api_values
 
     @property
     def namespaces(self) -> list[str]:

--- a/variantlib/plugins/loader.py
+++ b/variantlib/plugins/loader.py
@@ -423,6 +423,12 @@ class ManualPluginLoader(BasePluginLoader):
         self._plugins = {}
         super().__init__(python_ctx=ExternalNonIsolatedPythonEnv().__enter__())
 
+    def __enter__(self) -> Self:
+        return self
+
+    def __exit__(self, *args: object) -> None:
+        self._plugins = {}
+
     def __del__(self) -> None:
         self._python_ctx.__exit__()
 


### PR DESCRIPTION
- replace `CLIPluginLoader` with `EntryPointPluginLoader` that loads all plugins via entry points
- update the commands to use the new loader
- make `make-variant` automatically determine `plugin-api` from installed plugins
- switch tests back to `ManualPluginLoader` to simplify them