### PR TITLE
Introduce a `WheelMetadata` subclass

### DIFF
--- a/tests/test_wheel_metadata.py
+++ b/tests/test_wheel_metadata.py
@@ -1,0 +1,91 @@
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+import pytest
+
+from variantlib.constants import VARIANT_DIST_INFO_FILENAME
+from variantlib.errors import ValidationError
+from variantlib.models.metadata import ProviderInfo
+from variantlib.models.metadata import VariantMetadata
+from variantlib.models.variant import VariantDescription
+from variantlib.models.variant import VariantProperty
+from variantlib.wheel_metadata import WheelMetadata
+
+VARIANT_JSON = """
+{
+    "default-priorities": {
+        "namespace": [
+            "ns"
+        ],
+        "feature": {},
+        "property": {}
+    },
+    "providers": {
+        "ns": {
+            "requires": [
+                "ns-pkg"
+            ]
+        }
+    },
+    "variants": {
+        "bdbc6ca0": {
+            "ns": {
+                "f": "v"
+            }
+        }
+    }
+}
+"""
+
+
+@pytest.mark.parametrize("json_type", [str, bytes])
+@pytest.mark.parametrize("expected_hash", [None, "bdbc6ca0"])
+def test_wheel_metadata(json_type: type, expected_hash: str | None) -> None:
+    VARIANT_JSON if json_type is str else VARIANT_JSON.encode()
+    metadata = WheelMetadata(VARIANT_JSON, expected_hash=expected_hash)
+    assert metadata.namespace_priorities == ["ns"]
+    assert metadata.feature_priorities == {}
+    assert metadata.property_priorities == {}
+    assert metadata.providers == {"ns": ProviderInfo(requires=["ns-pkg"])}
+    vdesc = VariantDescription([VariantProperty("ns", "f", "v")])
+    assert metadata.variants == {vdesc.hexdigest: vdesc}
+    assert metadata.variant_desc == vdesc
+    assert metadata.variant_hash == vdesc.hexdigest
+
+
+def test_wheel_metadata_wrong_hash() -> None:
+    with pytest.raises(
+        ValidationError,
+        match=re.escape(
+            f"{VARIANT_DIST_INFO_FILENAME} specifies hash bdbc6ca0, expected 00000000"
+        ),
+    ):
+        WheelMetadata(VARIANT_JSON, expected_hash="00000000")
+
+
+def test_wheel_metadata_multiple_variants() -> None:
+    json_file = Path("tests/artifacts/variants.json")
+    assert json_file.exists(), "Expected JSON file does not exist"
+
+    with pytest.raises(
+        ValidationError,
+        match=re.escape(
+            f"{VARIANT_DIST_INFO_FILENAME} specifies 6 variants, expected exactly one"
+        ),
+    ):
+        WheelMetadata(json_file.read_text())
+
+
+def test_new_wheel_metadata() -> None:
+    vmeta = VariantMetadata(
+        namespace_priorities=["ns"], providers={"ns": ProviderInfo(requires=["ns-pkg"])}
+    )
+    metadata = WheelMetadata(vmeta)
+    vdesc = VariantDescription([VariantProperty("ns", "f", "v")])
+    metadata.variant_desc = vdesc
+    assert metadata.namespace_priorities == vmeta.namespace_priorities
+    assert metadata.providers == vmeta.providers
+    assert metadata.variant_hash == vdesc.hexdigest
+    assert metadata.variant_desc == vdesc

--- a/variantlib/api.py
+++ b/variantlib/api.py
@@ -24,6 +24,7 @@ from variantlib.utils import aggregate_feature_priorities
 from variantlib.utils import aggregate_namespace_priorities
 from variantlib.utils import aggregate_property_priorities
 from variantlib.variants_json import VariantsJson
+from variantlib.wheel_metadata import WheelMetadata
 
 if TYPE_CHECKING:
     from variantlib.protocols import VariantFeatureName
@@ -173,8 +174,8 @@ def make_variant_dist_info(
     # If not, start with an empty class.
     if variant_metadata is None:
         variant_metadata = VariantMetadata()
-    variant_json = VariantsJson(variant_metadata)
-    variant_json.variants[vdesc.hexdigest] = vdesc
+    variant_json = WheelMetadata(variant_metadata)
+    variant_json.variant_desc = vdesc
 
     return variant_json.to_str()
 

--- a/variantlib/models/metadata.py
+++ b/variantlib/models/metadata.py
@@ -6,7 +6,6 @@ from typing import TYPE_CHECKING
 from typing import Any
 
 from packaging.requirements import Requirement
-
 from variantlib.constants import VALIDATION_FEATURE_NAME_REGEX
 from variantlib.constants import VALIDATION_NAMESPACE_REGEX
 from variantlib.constants import VALIDATION_PROVIDER_ENABLE_IF_REGEX

--- a/variantlib/plugins/loader.py
+++ b/variantlib/plugins/loader.py
@@ -18,7 +18,6 @@ from typing import Any
 from packaging.markers import Marker
 from packaging.markers import default_environment
 from packaging.requirements import Requirement
-
 from variantlib.constants import VALIDATION_PROVIDER_PLUGIN_API_REGEX
 from variantlib.errors import NoPluginFoundError
 from variantlib.errors import PluginError

--- a/variantlib/wheel_metadata.py
+++ b/variantlib/wheel_metadata.py
@@ -1,0 +1,55 @@
+from __future__ import annotations
+
+import json
+from dataclasses import dataclass
+from typing import TYPE_CHECKING
+
+from variantlib.constants import VARIANT_DIST_INFO_FILENAME
+from variantlib.errors import ValidationError
+from variantlib.models.metadata import VariantMetadata
+from variantlib.variants_json import VariantsJson
+
+if TYPE_CHECKING:
+    from variantlib.models.variant import VariantDescription
+
+
+@dataclass(init=False)
+class WheelMetadata(VariantsJson):
+    def __init__(
+        self,
+        metadata_file: bytes | str | VariantMetadata,
+        expected_hash: str | None = None,
+    ) -> None:
+        """Init from pre-read metadata file"""
+
+        if isinstance(metadata_file, VariantMetadata):
+            # Convert from another related class.
+            super().__init__(metadata_file)
+            return
+
+        self._process(json.loads(metadata_file))
+
+        if len(self.variants) != 1:
+            raise ValidationError(
+                f"{VARIANT_DIST_INFO_FILENAME} specifies "
+                f"{len(self.variants)} variants, expected exactly one"
+            )
+        if expected_hash not in (None, self.variant_hash):
+            raise ValidationError(
+                f"{VARIANT_DIST_INFO_FILENAME} specifies hash "
+                f"{self.variant_hash}, expected {expected_hash}"
+            )
+
+    @property
+    def variant_hash(self) -> str:
+        assert len(self.variants) == 1
+        return next(iter(self.variants.keys()))
+
+    @property
+    def variant_desc(self) -> VariantDescription:
+        assert len(self.variants) == 1
+        return next(iter(self.variants.values()))
+
+    @variant_desc.setter
+    def variant_desc(self, new_desc: VariantDescription) -> None:
+        self.variants = {new_desc.hexdigest: new_desc}


### PR DESCRIPTION
Introduce a `WheelMetadata` subclass that provides a more convenient API to access the `variant.json` data from wheels.  Notably, it adds verification that the file contains only one variant (with an option to verify its hash against the filename) and properties to query the variant description and hash, and to set it.