### PR TITLE
Support `none` namespace for non-plugin properties

### DIFF
--- a/variantlib/constants.py
+++ b/variantlib/constants.py
@@ -8,6 +8,7 @@ VARIANT_HASH_LEN = 8
 NULL_VARIANT_LABEL = "null"
 CONFIG_FILENAME = "variants.toml"
 VARIANT_DIST_INFO_FILENAME = "variant.json"
+NAMESPACE_NONE = "none"
 
 # Common variant info keys (used in pyproject.toml and variants.json)
 VARIANT_INFO_DEFAULT_PRIO_KEY: Literal["default-priorities"] = "default-priorities"


### PR DESCRIPTION
Reserve a special namespace called `none` for the purpose of declaring variant properties that aren't handled by any plugin but the package itself. The valid features and their values, as well as their ordering, are fully specified in `pyproject.toml` then, for example:

```
[variant.default-priorities]
namespace = [..., "none"]
feature.none = ["blas", "build"]
property.none.blas = ["accelerate", "openblas", "mkl", "netlib"]
property.none.build = ["release", "debug"]
```

The following rules apply:

1. If the `none` namespace, the feature name and the value are present in `variant.default-priorities`, the property is considered both valid and supported. Otherwise, it's considered invalid.

2. `variant.providers.none` must never be specified (since it can't use a plugin).

3. Ordering is implied by the `variant.default-priorities` table, the same as it would sort regular properties.

For the implementation, I've chosen to:

1. Add a `VariantInfo.get_none_properties()` method that assembles the dictionary of valid/supported properties from the variant information.

2. Modify `BasePluginLoader` to account for `none` properties specially. This implies that we technically can skip plugins entirely when dealing with variants that use `none` properties only.

See https://github.com/wheelnext/pep_xxx_wheel_variants/issues/18