### PR TITLE
Add a `has_fixed_supported_configs` plugin property

### DIFF
--- a/tests/mocked_plugins.py
+++ b/tests/mocked_plugins.py
@@ -18,6 +18,8 @@ class MockedEntryPoint:
 class MockedPluginA(PluginType):
     namespace = "test_namespace"  # pyright: ignore[reportAssignmentType,reportIncompatibleMethodOverride]
 
+    has_fixed_supported_configs = True
+
     def get_all_configs(self) -> list[VariantFeatureConfigType]:
         return [
             VariantFeatureConfig("name1", ["val1a", "val1b", "val1c", "val1d"]),

--- a/variantlib/api.py
+++ b/variantlib/api.py
@@ -202,7 +202,9 @@ def make_variant_dist_info(
                 filter_plugins=list(build_namespaces),
                 include_build_plugins=True,
             ) as plugin_loader:
-                configs = plugin_loader.get_supported_configs().values()
+                configs = plugin_loader.get_supported_configs(
+                    require_fixed=True
+                ).values()
 
             for config in configs:
                 if config.namespace not in build_namespaces:

--- a/variantlib/protocols.py
+++ b/variantlib/protocols.py
@@ -67,6 +67,17 @@ class PluginType(Protocol):
         """Plugin namespace"""
         raise NotImplementedError
 
+    @property
+    def has_fixed_supported_configs(self) -> bool:
+        """
+        Does get_supported_configs() return a fixed list?
+
+        If this is True, then get_supported_configs() must return a fixed
+        list that does not depend on platform in any way.  This permits
+        the plugin being used with 'plugin-use = "build"'.
+        """
+        return False
+
     @abstractmethod
     def get_all_configs(self) -> list[VariantFeatureConfigType]:
         """Get all valid configs for the plugin"""


### PR DESCRIPTION
Add a `has_fixed_supported_configs` that indicates whether `get_supported_configs()` always returns a fixed list that does not depend on the system state.  Only plugins featuring this flag can be used with `plugin-use = "build"`.