### PR TITLE
Add `is_build_plugin` plugin property to indicate additional requirements for `build-plugins`

### DIFF
--- a/tests/mocked_plugins.py
+++ b/tests/mocked_plugins.py
@@ -18,6 +18,8 @@ class MockedEntryPoint:
 class MockedPluginA(PluginType):
     namespace = "test_namespace"  # pyright: ignore[reportAssignmentType,reportIncompatibleMethodOverride]
 
+    has_fixed_supported_configs = True
+
     def get_all_configs(self) -> list[VariantFeatureConfigType]:
         return [
             VariantFeatureConfig("name1", ["val1a", "val1b", "val1c", "val1d"]),

--- a/tests/mocked_plugins.py
+++ b/tests/mocked_plugins.py
@@ -18,7 +18,7 @@ class MockedEntryPoint:
 class MockedPluginA(PluginType):
     namespace = "test_namespace"  # pyright: ignore[reportAssignmentType,reportIncompatibleMethodOverride]
 
-    has_fixed_supported_configs = True
+    is_build_plugin = True
 
     def get_all_configs(self) -> list[VariantFeatureConfigType]:
         return [

--- a/variantlib/api.py
+++ b/variantlib/api.py
@@ -202,7 +202,9 @@ def make_variant_dist_info(
                 filter_plugins=list(build_namespaces),
                 include_build_plugins=True,
             ) as plugin_loader:
-                configs = plugin_loader.get_supported_configs().values()
+                configs = plugin_loader.get_supported_configs(
+                    require_fixed=True
+                ).values()
 
             for config in configs:
                 if config.namespace not in build_namespaces:

--- a/variantlib/plugins/_subprocess.py
+++ b/variantlib/plugins/_subprocess.py
@@ -103,7 +103,7 @@ def main() -> int:
         non_fixed_plugins = {
             plugin.namespace
             for plugin in plugins.values()
-            if not getattr(plugin, "has_fixed_supported_configs", False)
+            if not getattr(plugin, "is_build_plugin", False)
         }
         if non_fixed_plugins:
             raise TypeError(

--- a/variantlib/protocols.py
+++ b/variantlib/protocols.py
@@ -67,6 +67,17 @@ class PluginType(Protocol):
         """Plugin namespace"""
         raise NotImplementedError
 
+    @property
+    def has_fixed_supported_configs(self) -> bool:
+        """
+        Does get_supported_configs() return a fixed list?
+
+        If this is True, then get_supported_configs() must return a fixed
+        list that does not depend on platform in any way.  This permits
+        the plugin being used with 'plugin-use = "build"'.
+        """
+        return False
+
     @abstractmethod
     def get_all_configs(self) -> list[VariantFeatureConfigType]:
         """Get all valid configs for the plugin"""

--- a/variantlib/protocols.py
+++ b/variantlib/protocols.py
@@ -68,13 +68,18 @@ class PluginType(Protocol):
         raise NotImplementedError
 
     @property
-    def has_fixed_supported_configs(self) -> bool:
+    def is_build_plugin(self) -> bool:
         """
-        Does get_supported_configs() return a fixed list?
+        Is this plugin valid for `plugin-use = "build"`?
 
-        If this is True, then get_supported_configs() must return a fixed
-        list that does not depend on platform in any way.  This permits
-        the plugin being used with 'plugin-use = "build"'.
+        If this is True, then `get_supported_configs()` must always
+        return the same values, irrespective of the platform used.
+        This permits the plugin to be used with `plugin-use = "build"`,
+        where the supported properties are recorded at build time.
+
+        If the value of `get_supported_configs()` may change in any way
+        depending on the platform used, then it must be False
+        (the default).
         """
         return False
 


### PR DESCRIPTION
Add a `is_build_plugin ` that indicates whether `get_supported_configs()` always returns a fixed list that does not depend on the system state.  Only plugins featuring this flag can be used with `plugin-use = "build"`.